### PR TITLE
Fix additional margins around paragraphs for rich-text-nodes in XHMTL.

### DIFF
--- a/freeplane/resources/html/treestyles.css
+++ b/freeplane/resources/html/treestyles.css
@@ -52,6 +52,13 @@ text-align:right;
   border-color:#dddddd;
 }
 
+div.nodecontent p:first-child {
+  display:inline;
+}
+div.nodecontent p + p:last-child {
+  margin-bottom:0;
+}
+
 h1 {
     text-align:center;
 }


### PR DESCRIPTION
This solves issue #1979 by adding some CSS style rules removing the margin.
