### PR TITLE
Fix: jgoodies 1.4 no longer accepts RowSpec(string) constructor.

### DIFF
--- a/freeplane/src/org/freeplane/core/resources/components/KeyProperty.java
+++ b/freeplane/src/org/freeplane/core/resources/components/KeyProperty.java
@@ -32,6 +32,7 @@ import org.freeplane.core.util.TextUtils;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.RowSpec;
+import com.jgoodies.forms.layout.Sizes;
 
 /**
  * @author Dimitry Polivaev
@@ -77,7 +78,7 @@ public class KeyProperty extends PropertyBean implements IPropertyControl {
 		String tooltip = TextUtils.getOptionalText(getDescription());
 		label.setToolTipText(tooltip);
 		if (KeyProperty.rowSpec == null) {
-			KeyProperty.rowSpec = new RowSpec("fill:20dlu");
+			KeyProperty.rowSpec = new RowSpec(RowSpec.FILL, Sizes.dluX(20), 0.0);
 		}
 		if (3 < builder.getColumn()) {
 			builder.appendRelatedComponentsGapRow();


### PR DESCRIPTION
The constructur which is now used is valid for jgoodies 1.2 and 1.4.
