### PR TITLE
Added an export filter allowing the creation of Asciidoc files from a Freeplane mind map

### DIFF
--- a/freeplane/external-resources/xslt/mm2adoc.xsl
+++ b/freeplane/external-resources/xslt/mm2adoc.xsl
@@ -31,9 +31,6 @@
 	</xsl:template>
 
 	<xsl:template match="richcontent">
-		<xsl:if test="@TYPE='DETAILS'">
-			<xsl:text></xsl:text>
-		</xsl:if>
 		<xsl:if test="@TYPE='NOTE'">
 			<xsl:text>NOTE: </xsl:text>
 		</xsl:if>


### PR DESCRIPTION
This XSL Transform file (mm2adoc.xsl) allows to export a Freeplane mindmaps into an Asciidoc file.
