### PR TITLE
Improved folding and connector popup

### DIFF
--- a/freeplane/src/org/freeplane/features/link/GotoLinkNodeAction.java
+++ b/freeplane/src/org/freeplane/features/link/GotoLinkNodeAction.java
@@ -22,6 +22,8 @@ package org.freeplane.features.link;
 import java.awt.event.ActionEvent;
 
 import javax.swing.Action;
+import javax.swing.JComponent;
+import javax.swing.SwingUtilities;
 
 import org.freeplane.core.ui.AFreeplaneAction;
 import org.freeplane.core.util.TextUtils;
@@ -37,11 +39,13 @@ class GotoLinkNodeAction extends AFreeplaneAction {
 	private static final long serialVersionUID = 1L;
 	private final LinkController linkController;
 	private final NodeModel target;
+	private final JComponent arrowLinkPopup;
 
-	public GotoLinkNodeAction(final LinkController linkController, final NodeModel target) {
+	public GotoLinkNodeAction(final LinkController linkController, final JComponent arrowLinkPopup, final NodeModel target) {
 		super("GotoLinkNodeAction");
 		this.target = target;
 		this.linkController = linkController;
+		this.arrowLinkPopup = arrowLinkPopup;
 		if (target != null) {
 			final String adaptedText = TextController.getController().getShortText(target);
 			putValue(Action.NAME, TextUtils.getText("follow_graphical_link") + adaptedText);
@@ -53,5 +57,6 @@ class GotoLinkNodeAction extends AFreeplaneAction {
 		linkController.onDeselect(Controller.getCurrentModeController().getMapController().getSelectedNode());
 		Controller.getCurrentModeController().getMapController().select(target);
 		linkController.onSelect(target);
+		SwingUtilities.getWindowAncestor(arrowLinkPopup).setVisible(false);
 	}
 }

--- a/freeplane/src/org/freeplane/features/link/LinkController.java
+++ b/freeplane/src/org/freeplane/features/link/LinkController.java
@@ -49,6 +49,7 @@ import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.event.PopupMenuEvent;
@@ -338,7 +339,7 @@ public class LinkController extends SelectionController implements IExtension {
 	public Component getPopupForModel(final java.lang.Object obj) {
 		if (obj instanceof ConnectorModel) {
 			final ConnectorModel link = (ConnectorModel) obj;
-			final Box arrowLinkPopup = Box.createVerticalBox();
+			final JPopupMenu arrowLinkPopup = new JPopupMenu();
 			arrowLinkPopup.setName(TextUtils.getText("connector"));
 			createArrowLinkPopup(link, arrowLinkPopup);
 			return arrowLinkPopup;

--- a/freeplane/src/org/freeplane/features/link/LinkController.java
+++ b/freeplane/src/org/freeplane/features/link/LinkController.java
@@ -148,7 +148,7 @@ public class LinkController extends SelectionController implements IExtension {
 	private void addLinks(final JComponent arrowLinkPopup, final NodeModel source) {
 		final IMapSelection selection = Controller.getCurrentModeController().getController().getSelection();
 		if (!selection.isSelected(source)) {
-			GotoLinkNodeAction gotoLinkNodeAction = new GotoLinkNodeAction(this, source);
+			GotoLinkNodeAction gotoLinkNodeAction = new GotoLinkNodeAction(this, arrowLinkPopup, source);
 			addAction(arrowLinkPopup, gotoLinkNodeAction);
 		}
 	}
@@ -233,11 +233,12 @@ public class LinkController extends SelectionController implements IExtension {
 	            				}
 	            				else
 	            					target = node.getMap().getNodeForID(targetID);
-	            				final GotoLinkNodeAction gotoLinkNodeAction = new GotoLinkNodeAction(LinkController.this, target);
-	            				if(!(link instanceof ConnectorModel)){
-	            					gotoLinkNodeAction.putValue(Action.SMALL_ICON, ICON_STORE.getUIIcon(LINK_LOCAL_ICON).getIcon());
-	            				}
-	            				builder.addAction(key, gotoLinkNodeAction, MenuBuilder.AS_CHILD);
+	            				// TODO: couldn't figure out what this does
+//	            				final GotoLinkNodeAction gotoLinkNodeAction = new GotoLinkNodeAction(LinkController.this, , target);
+//	            				if(!(link instanceof ConnectorModel)){
+//	            					gotoLinkNodeAction.putValue(Action.SMALL_ICON, ICON_STORE.getUIIcon(LINK_LOCAL_ICON).getIcon());
+//	            				}
+//	            				builder.addAction(key, gotoLinkNodeAction, MenuBuilder.AS_CHILD);
 	            			}
 	            		}
 

--- a/freeplane/src/org/freeplane/features/map/MapController.java
+++ b/freeplane/src/org/freeplane/features/map/MapController.java
@@ -289,8 +289,12 @@ public class MapController extends SelectionController implements IExtension{
 		nodeChangeListeners = new LinkedList<INodeChangeListener>();
 		createActions();
 	}
+	
 
-	public void setFolded(final NodeModel node, final boolean folded) {
+	/**
+	 * Don't call me directly!!! The basic folding method. Without undo.
+	 */
+	public void _setFolded(final NodeModel node, final boolean folded) {
 		if (node == null) {
 			throw new IllegalArgumentException("setFolded was called with a null node.");
 		}
@@ -310,6 +314,10 @@ public class MapController extends SelectionController implements IExtension{
 		}
 		else if(childShown)
 	        fireNodeUnfold(node);
+	}
+
+	public void setFolded(final NodeModel node, final boolean folded) {
+		_setFolded(node, folded);
 	}
 
 	public boolean showNextChild(final NodeModel node) {

--- a/freeplane/src/org/freeplane/view/swing/ui/DefaultNodeMouseMotionListener.java
+++ b/freeplane/src/org/freeplane/view/swing/ui/DefaultNodeMouseMotionListener.java
@@ -88,7 +88,7 @@ public class DefaultNodeMouseMotionListener implements IMouseListener {
 					return;
 				}
 
-				if(inside && e.getClickCount() == 1 && ResourceController.getResourceController().getBooleanProperty(FOLD_ON_CLICK_INSIDE)){
+				if(inside && ResourceController.getResourceController().getBooleanProperty(FOLD_ON_CLICK_INSIDE)){
 					final boolean fold = FoldingMark.UNFOLDED.equals(component.foldingMarkType(mapController, node)) && ! mapController.hasHiddenChildren(node);
 					if (!nodeSelector.shouldSelectOnClick(e)) {
 						doubleClickTimer.start(new Runnable() {


### PR DESCRIPTION
Hi all

Thanks for the great work with FreePlane! I use it every day. In the forum, I made some suggestions some time ago [1]. Today I made an attempt to implement them.
1. When clicking a connector, the popup was displayed as normal window. I use Linux with a tiling window manager (i3wm), so the popup screwed up the screen layout. I have replaced the javax.swing.Box by a javax.swing.JPopupMenu (baabf74).
2. e4af8a7 automatically closes the popup when the "Goto:" button was clicked; this seemed more natural to me. I am not sure what the code in freeplane/src/org/freeplane/features/link/LinkController.java, line 235ff, does :-(. Could you please help me get this bit right too?
3. Folding used to work (in 1.1.3) by double clicking into the node. In the current version, only single clicks toggled the fold. I have changed this in 3c30077.
4. Also in 1.1.3, the folding was part of the undo/redo history. This was gone since 1.2.x. I have added it back (e1ee218).

I would appreciate if you merge my changes into your master. Thanks a lot!

Regards,
Benedikt

[1] https://sourceforge.net/apps/phpbb/freeplane/viewtopic.php?f=1&t=783&p=3835#p3835
