### PR TITLE
Fix path to version file

### DIFF
--- a/freeplane/src/org/freeplane/main/addons/AddOnProperties.java
+++ b/freeplane/src/org/freeplane/main/addons/AddOnProperties.java
@@ -261,8 +261,8 @@ public class AddOnProperties {
 
     private URL homepagePlusLatestVersionFile() {
         try {
-            final File file = new File(homepage.getPath(), AddOnsController.LATEST_VERSION_FILE);
-            return new URL(homepage.getProtocol(), homepage.getHost(), homepage.getPort(), file.getPath());
+       	    final String file = homepage.getPath() + "/" + AddOnsController.LATEST_VERSION_FILE;
+            return new URL(homepage.getProtocol(), homepage.getHost(), homepage.getPort(), file);
         }
         catch (MalformedURLException e) {
             return null;


### PR DESCRIPTION
Under windows we can't use the File constructor to build the path to the version file since it uses de "\" as path separator.
This fix proposes to hardcode the "/" as path separator.
