### PR TITLE
Add initial editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+
+[*.java]
+indent_style = tab


### PR DESCRIPTION
I am working with IntelliJ, which uses editorconfig to keep the files consistent.

I saw that in `*.java`, tab is used. In the other files (e..g, `build.gradle`), there is a mix between tabs and spaces. I don't know, where the project aims for in this regard, but this editorconfig can be a good start to harmonize tabs and spaces in the project.

For more infomration on editorconfig see http://editorconfig.org/