### PR TITLE
Update JGoodies

### DIFF
--- a/freeplane/build.gradle
+++ b/freeplane/build.gradle
@@ -12,8 +12,8 @@ dependencies {
     compile 'commons-lang:commons-lang:2.6',
             'commons-io:commons-io:2.4',
             'commons-codec:commons-codec:1.7',
-            'com.jgoodies:jgoodies-forms:1.6.0',
-            'com.jgoodies:jgoodies-common:1.4.0'
+            'com.jgoodies:jgoodies-forms:1.9.0',
+            'com.jgoodies:jgoodies-common:1.8.1'
 
 	compile  ('com.lightdev.app.shtm.simplyhtml:SimplyHTML:0.16.18') {
 		exclude module: 'javahelp'

--- a/freeplane/src/main/java/org/freeplane/core/resources/components/OptionPanel.java
+++ b/freeplane/src/main/java/org/freeplane/core/resources/components/OptionPanel.java
@@ -50,6 +50,7 @@ import javax.swing.event.ChangeListener;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.tree.DefaultMutableTreeNode;
 
+import com.jgoodies.forms.factories.Borders;
 import org.apache.commons.lang.StringUtils;
 import org.dpolivaev.mnemonicsetter.MnemonicSetter;
 import org.freeplane.core.resources.ResourceController;
@@ -134,7 +135,7 @@ public class OptionPanel {
 				final TabProperty newTab = (TabProperty) control;
 				bottomLayout = new FormLayout(newTab.getName(), "");
 				bottomBuilder = new DefaultFormBuilder(bottomLayout);
-				bottomBuilder.setDefaultDialogBorder();
+				bottomBuilder.border(Borders.DIALOG);
 				final JScrollPane bottomComponent = new JScrollPane(bottomBuilder.getPanel());
 				UITools.setScrollbarIncrement(bottomComponent);
 				final String tabName = TextUtils.getOptionalText(newTab.getLabel());


### PR DESCRIPTION
Debian updated jgoodies forms from 1.6.0 to 1.9.0 (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=819669) and jgoodies common from 1.4.0 to 1.8.1 (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=819668). The changelog of jgoodies-forms 1.9.0 reads:

    This version is binary incompatible with previous versions,
    primarily because deprecated code has been removed.
    Migration is necessary (but easy) only for those API users
    that have used the open source ListViewBuilder instead of
    the commercial ListViewBuilder, and that have used deprecated
    methods in PanelBuilder and DefaultFormBuilder.

Thus, freeplane 1.5.1 does not build anymore. Fortunately, to make it compiling again, only a small patch is required. This patch is provided here.