### PR TITLE
Support non default http port "Open map from URL"

### DIFF
--- a/freeplane/src/main/java/org/freeplane/features/url/FreeplaneUriConverter.java
+++ b/freeplane/src/main/java/org/freeplane/features/url/FreeplaneUriConverter.java
@@ -48,7 +48,7 @@ public class FreeplaneUriConverter{
 	    	return new URL(UrlManager.FILE_SCHEME, uri.getHost(), uri.getPath().substring(2));
 	    }
 	    else
-	    	return new URL(scheme, uri.getHost(), uri.getPath());
+	    	return new URL(scheme, uri.getHost(), uri.getPort(), uri.getPath());
     }
 
 	public String fixPartiallyDecodedFreeplaneUriComingFromInternetExplorer(String uriCandidate) {


### PR DESCRIPTION
Freeplane cannot load URL with non default http port because the FreeplaneUriConverter removes the port part of the URL.