### PR TITLE
Replace 1.8 API call with 1.7 equivalent code.

### DIFF
--- a/freeplane/src/main/java/org/freeplane/features/presentations/mindmapmode/NamedElementCollection.java
+++ b/freeplane/src/main/java/org/freeplane/features/presentations/mindmapmode/NamedElementCollection.java
@@ -163,9 +163,16 @@ public class NamedElementCollection<T extends NamedElement<T>> implements Iterab
 			@Override
 			public T next() {
 				if(hasNext())
-					return getElement(index++);
+					return NamedElementCollection.this.getElement(index++);
 				else
 					throw new NoSuchElementException();
+			}
+
+			@Override
+			public void remove() {
+				if (index > getSize())
+					throw new NoSuchElementException();
+				NamedElementCollection.this.removeCurrentElement();
 			}
 		};
 	}

--- a/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
+++ b/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.swing.BorderFactory;
@@ -551,7 +552,12 @@ abstract public class FrameController implements ViewController {
 		final ResourceController resourceController = ResourceController.getResourceController();
 
 		@SuppressWarnings("unused")
-		final boolean removeBadValueForABugFix = resourceController.getProperties().remove(UITools.MENU_ITEM_FONT_SIZE_PROPERTY, "100");
+		boolean removeBadValueForABugFix = false;
+		if (resourceController.getProperties().containsKey(UITools.MENU_ITEM_FONT_SIZE_PROPERTY)
+				&& Objects.equals(resourceController.getProperties().get(UITools.MENU_ITEM_FONT_SIZE_PROPERTY), "100")) {
+			resourceController.getProperties().remove(UITools.MENU_ITEM_FONT_SIZE_PROPERTY);
+			removeBadValueForABugFix = true;
+		}
 
 		int lookAndFeelDefaultMenuItemFontSize = getLookAndFeelDefaultMenuItemFontSize();
 		final long defaultMenuItemSize = Math.round(lookAndFeelDefaultMenuItemFontSize * DEFAULT_SCALING_FACTOR);


### PR DESCRIPTION
The java.util.Map.remove(Object key, Object value) is > 1.8 and since
the project should work with 1.7 replace this with the expanded
implementation.

Signed-off-by: Leonidas Spyropoulos <artafinde@gmail.com>