### PR TITLE
Fix for #2386 Special characters in add-on translations wrongly displayed

### DIFF
--- a/freeplane/src/main/java/org/freeplane/core/util/TextUtils.java
+++ b/freeplane/src/main/java/org/freeplane/core/util/TextUtils.java
@@ -1,8 +1,12 @@
 package org.freeplane.core.util;
 
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.text.DecimalFormat;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import org.freeplane.core.resources.ResourceBundles;
@@ -192,5 +196,109 @@ public class TextUtils {
 	/** Shortcut for scripting: Copies <code>html</code> with mimetype text/html to the system clipboard. */
 	public static void copyHtmlToClipboard(String html) {
 		ClipboardAccessor.getController().setClipboardContentsToHtml(html);
+	}
+	/*
+	 * The escapeUtf8 method is a stripped down version of the
+	 * StringEscapeUtils.escapeJava method in Commons Lang 2.6 
+	 */
+
+	/**
+	 * Escapes the UTF-8 non-ASCII characters in a <code>String</code>.
+	 * <p>
+	 * Such a character becomes <code>'\\'</code> and <code>'u'</code> followed by
+	 * a 4 digit hex code.
+	 * <p>
+	 * Any ASCII character will stay intact
+	 * <p>
+	 * Example:
+	 * <pre>
+	 * input string: jalapeño
+	 * output string: jalape\u00F1o
+	 * </pre>
+	 *
+	 * @param str  String to escape values in, may be null
+	 * @return String with escaped values, <code>null</code> if null string input
+	 */
+	public static String escapeUtf8(String str) {
+		return escapeUtf8StyleString(str);
+	}
+	
+	/**
+	 * Escapes the UTF-8 non-ASCII characters in a <code>String</code> to
+	 * a <code>Writer</code>.
+	 * <p>
+	 * A <code>null</code> string input has no effect.
+	 *
+	 * @see #escapeUtf8(java.lang.String)
+	 * @param out  Writer to write escaped string into
+	 * @param str  String to escape values in, may be null
+	 * @throws IllegalArgumentException if the Writer is <code>null</code>
+	 * @throws IOException if error occurs on underlying Writer
+	 */
+	public static void escapeUtf8(Writer out, String str) throws IOException {
+		escapeUtf8StyleString(out, str);
+	}
+	
+	/**
+	 * Worker method for the {@link #escapeUtf8(String)} method.
+	 *
+	 * @param str String to escape values in, may be null
+	 * @return the escaped string
+	 */
+	private static String escapeUtf8StyleString(String str) {
+		if (str == null) {
+			return null;
+		}
+		try {
+			StringWriter writer = new StringWriter(str.length() * 2);
+			escapeUtf8StyleString(writer, str);
+			return writer.toString();
+		} catch (IOException ioe) {
+			// this should never ever happen while writing to a StringWriter
+			throw new RuntimeException(ioe);
+		}
+	}
+	
+	/**
+	 * Worker method for the {@link #escapeUtf8(Writer, String)} method.
+	 *
+	 * @param out write to receive the escaped string
+	 * @param str String to escape values in, may be null
+	 * @throws IOException if an IOException occurs
+	 */
+	private static void escapeUtf8StyleString(Writer out, String str) throws IOException {
+		if (out == null) {
+			throw new IllegalArgumentException("The Writer must not be null");
+		}
+		if (str == null) {
+			return;
+		}
+		int sz;
+		sz = str.length();
+		for (int i = 0; i < sz; i++) {
+			char ch = str.charAt(i);
+	
+			// handle unicode
+			if (ch > 0xfff) {
+				out.write("\\u" + hex(ch));
+			} else if (ch > 0xff) {
+				out.write("\\u0" + hex(ch));
+			} else if (ch > 0x7f) {
+				out.write("\\u00" + hex(ch));
+			} else {
+				out.write(ch);
+			}
+		}
+	}
+	
+	/**
+	 * Returns an upper case hexadecimal <code>String</code> for the given
+	 * character.
+	 *
+	 * @param ch The character to convert.
+	 * @return An upper case hexadecimal <code>String</code>
+	 */
+	private static String hex(char ch) {
+		return Integer.toHexString(ch).toUpperCase(Locale.ENGLISH);
 	}
 }

--- a/freeplane/src/main/java/org/freeplane/core/util/TextUtils.java
+++ b/freeplane/src/main/java/org/freeplane/core/util/TextUtils.java
@@ -197,13 +197,12 @@ public class TextUtils {
 	public static void copyHtmlToClipboard(String html) {
 		ClipboardAccessor.getController().setClipboardContentsToHtml(html);
 	}
-	/*
-	 * The escapeUtf8 method is a stripped down version of the
-	 * StringEscapeUtils.escapeJava method in Commons Lang 2.6 
-	 */
 
 	/**
-	 * Escapes the UTF-8 non-ASCII characters in a <code>String</code>.
+	 * The escapeUtf8 method is a stripped down version of the
+	 * StringEscapeUtils.escapeJava method in Commons Lang 2.6 
+	 * 
+	 * It escapes the UTF-8 non-ASCII characters in a <code>String</code>.
 	 * <p>
 	 * Such a character becomes <code>'\\'</code> and <code>'u'</code> followed by
 	 * a 4 digit hex code.
@@ -239,12 +238,6 @@ public class TextUtils {
 		escapeUtf8StyleString(out, str);
 	}
 	
-	/**
-	 * Worker method for the {@link #escapeUtf8(String)} method.
-	 *
-	 * @param str String to escape values in, may be null
-	 * @return the escaped string
-	 */
 	private static String escapeUtf8StyleString(String str) {
 		if (str == null) {
 			return null;
@@ -259,13 +252,6 @@ public class TextUtils {
 		}
 	}
 	
-	/**
-	 * Worker method for the {@link #escapeUtf8(Writer, String)} method.
-	 *
-	 * @param out write to receive the escaped string
-	 * @param str String to escape values in, may be null
-	 * @throws IOException if an IOException occurs
-	 */
 	private static void escapeUtf8StyleString(Writer out, String str) throws IOException {
 		if (out == null) {
 			throw new IllegalArgumentException("The Writer must not be null");
@@ -291,13 +277,6 @@ public class TextUtils {
 		}
 	}
 	
-	/**
-	 * Returns an upper case hexadecimal <code>String</code> for the given
-	 * character.
-	 *
-	 * @param ch The character to convert.
-	 * @return An upper case hexadecimal <code>String</code>
-	 */
 	private static String hex(char ch) {
 		return Integer.toHexString(ch).toUpperCase(Locale.ENGLISH);
 	}

--- a/freeplane/src/main/java/org/freeplane/main/addons/AddOnProperties.java
+++ b/freeplane/src/main/java/org/freeplane/main/addons/AddOnProperties.java
@@ -453,7 +453,7 @@ public class AddOnProperties {
 			for (Entry<String, String> translationEntry : localeEntry.getValue().entrySet()) {
 				final XMLElement translationElement = new XMLElement("entry");
 				translationElement.setAttribute("key", translationEntry.getKey());
-				translationElement.setContent(StringEscapeUtils.escapeJava(translationEntry.getValue()));
+				translationElement.setContent(translationEntry.getValue());
 				localeElement.addChild(translationElement);
 			}
 			translationsElement.addChild(localeElement);

--- a/freeplane/src/main/java/org/freeplane/main/addons/AddOnProperties.java
+++ b/freeplane/src/main/java/org/freeplane/main/addons/AddOnProperties.java
@@ -17,7 +17,6 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Vector;
 
-import org.apache.commons.lang.StringEscapeUtils;
 import org.freeplane.core.util.FreeplaneVersion;
 import org.freeplane.core.util.TextUtils;
 import org.freeplane.n3.nanoxml.CdataContentXmlWriter;
@@ -453,7 +452,7 @@ public class AddOnProperties {
 			for (Entry<String, String> translationEntry : localeEntry.getValue().entrySet()) {
 				final XMLElement translationElement = new XMLElement("entry");
 				translationElement.setAttribute("key", translationEntry.getKey());
-				translationElement.setContent(translationEntry.getValue());
+				translationElement.setContent(TextUtils.escapeUtf8(translationEntry.getValue()));
 				localeElement.addChild(translationElement);
 			}
 			translationsElement.addChild(localeElement);


### PR DESCRIPTION
Added method `escapeUtf8` to `org.freeplane.core.util.TextUtils`. Method
`escapeUtf8` is a stripped down version of `StringEscapeUtils.escapeJava`. It
only escapes UTF-8 non-ASCII characters. It escapes them to \uXXXX where
XXXX is the hex code of the escaped character. It solves this bug
because it does not escape backslashes and double quotes.

Replaced method `StringEscapeUtils.escapeJava` with
`TextUtils.escapeUtf8` on line 456 of
`org.freeplane.main.addons.AddOnProperties`.

As part of the fix of this bug the add-on `devtools` is also changed to
use `TextUtils.escapeUtf8`.