### PR TITLE
Fix for Javadoc escapeUtf8 in org.freeplane.core.util.TextUtils

### DIFF
--- a/freeplane/src/main/java/org/freeplane/core/util/TextUtils.java
+++ b/freeplane/src/main/java/org/freeplane/core/util/TextUtils.java
@@ -212,7 +212,7 @@ public class TextUtils {
 	 * Example:
 	 * <pre>
 	 * input string: jalapeño
-	 * output string: jalape\u00F1o
+	 * output string: jalape<code>\u00F1</code>o
 	 * </pre>
 	 *
 	 * @param str  String to escape values in, may be null


### PR DESCRIPTION
In merged pull request #117 the new method `escapeUtf8` was added to
`org.freeplane.core.util.TextUtils`. There is a small mistake in the
example in Javadoc. It reads:

> input string: jalapeño
> output string: jalapeño

It should read

> input string: jalapeño
> output string: jalape\u00F1o

Somehow `\u00F1` gets unescaped when creating the Javadoc. This is
strange because the Javadoc preview shows it correct A double backslash
in the same text is not escaped, but it is enclosed with `<code>` tags.
I have enclosed `\u00F1` also with `<code>` tags. Hopefully that will
solve the problem.

![image](https://user-images.githubusercontent.com/8525411/51441781-8bc3fd80-1cd5-11e9-84c1-f514462b2bc1.png)
