### PR TITLE
Separate gradle wrapper file for gradlew during travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: trusty
 jdk:
   - openjdk8
   - oraclejdk8
+  - oraclejdk11
 
 #fails on because because java 9.0.1 is not compatible with gradle 4.0 currently used by travis
 # https://github.com/travis-ci/travis-ci/issues/8975
@@ -15,7 +16,7 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
 script: 
-  - gradle -PTestLoggingFull=true check_translation check
+  - ./gradlew -PTestLoggingFull=true check_translation check
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -23,3 +24,5 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+before_install:
+  JAVA_HOME=/usr/lib/jvm/java-8-oracle gradle -b wrapper.gradle wrapper

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -1,0 +1,3 @@
+task wrapper(type: Wrapper, overwrite: true) {
+    gradleVersion = '5.1.1'
+}


### PR DESCRIPTION
This use local `java` (JDK 8) and local `gradle` (4.0.1) from the travis ubuntu image to install gradle wrapper (v5.1.1) before building and running the tests against JDK 8 and 11. You can check the travis build [here]. This can close #118 

[here]: https://travis-ci.org/inglor/freeplane/builds/482154225