### PR TITLE
Fix Central 501 HTTPS Required when fetching maven dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ subprojects {
 
     repositories {
        maven  {
-        url "http://repo1.maven.org/maven2"
+        url "https://repo1.maven.org/maven2"
        }
     }
 


### PR DESCRIPTION
Effective January 15, 2020, The Central Repository no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS, see https://www.alphabot.com/security/blog/2020/java/Your-Java-builds-might-break-starting-January-13th.html

Signed-off-by: Leonidas Spyropoulos <artafinde@gmail.com>