### PR TITLE
User/viaa

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,6 @@ subprojects {
 	targetCompatibility='1.8'
 	sourceCompatibility='1.8'
 
-
     tasks.withType(JavaCompile) {
       options.encoding = "UTF-8"
     }

--- a/freeplane/src/main/java/org/freeplane/features/link/mindmapmode/SetLinkByTextFieldAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/link/mindmapmode/SetLinkByTextFieldAction.java
@@ -100,6 +100,7 @@ class SetLinkByTextFieldAction extends AFreeplaneAction {
 				linkController.setLink(selectedNode, (URI) null, LinkController.LINK_ABSOLUTE);
 				return;
 			}
+            inputValue = inputValue.replace("\"", ""); // AV2021-04-18_22-25-23 (This is to remove the " when a link is pasted from Windows Explorer shift+right-click > Copy as path.)
 			try {
 				final URI link = LinkController.createURI(inputValue.trim());
 				linkController.setLink(selectedNode, link, LinkController.LINK_ABSOLUTE);

--- a/freeplane_debughelper/build.gradle
+++ b/freeplane_debughelper/build.gradle
@@ -8,7 +8,7 @@ repositories {
 dependencies {
 	def exclusions = [project.name, 'freeplane_ant']
 	if (! Os.isFamily(Os.FAMILY_MAC)) {
-		exclusions.add('freeplane_mac')
+    		exclusions.add('freeplane_mac')
 	}
 	parent.subprojects.findAll{! exclusions.contains(it.name)}.each {
 		runtimeOnly it


### PR DESCRIPTION
The small change (1 line added) to SetLinkByTextFieldAction.java is just to be able to paste in links, paths that contain double quotes, like "c:\temp" instead of c:\temp.
The double-quotes come from Windows Explorer, doing a right-click on a file while holding the shift key will show the contextual menu in Windows Explorer and (the shift key) will add "Copy as path" option. This copies the path of the file but adds double quotes.