### PR TITLE
remove leaked listeners related to single map view instance

### DIFF
--- a/freeplane/src/main/java/org/freeplane/view/swing/features/BlinkingNodeHook.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/features/BlinkingNodeHook.java
@@ -154,6 +154,9 @@ public class BlinkingNodeHook extends PersistentNodeHook {
 		public void onRemove(final MapModel map) {
 			if (node.getMap().equals(map)) {
 				timer.stop();
+				final MapController mapController = Controller.getCurrentModeController().getMapController();
+				mapController.removeMapChangeListener(this);
+				mapController.removeMapLifeCycleListener(this);
 			}
 		}
 	}

--- a/freeplane/src/main/java/org/freeplane/view/swing/features/time/mindmapmode/ReminderExtension.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/features/time/mindmapmode/ReminderExtension.java
@@ -31,6 +31,7 @@ import org.freeplane.core.ui.components.UITools;
 import org.freeplane.core.util.LogUtils;
 import org.freeplane.core.util.TextUtils;
 import org.freeplane.features.map.IMapChangeListener;
+import org.freeplane.features.map.IMapLifeCycleListener;
 import org.freeplane.features.map.MapModel;
 import org.freeplane.features.map.NodeDeletionEvent;
 import org.freeplane.features.map.NodeModel;
@@ -43,7 +44,7 @@ import org.freeplane.view.swing.features.time.mindmapmode.nodelist.ShowPastRemin
 /**
  * @author Dimitry Polivaev 30.11.2008
  */
-public class ReminderExtension implements IExtension, IMapChangeListener {
+public class ReminderExtension implements IExtension, IMapChangeListener, IMapLifeCycleListener {
     private static final ShowPastRemindersOnce pastReminders = new ShowPastRemindersOnce();
     private static final int BLINKING_PERIOD = 1000;
     private static final int MAXIMAL_DELAY = (int) Duration.ofMinutes(5).toMillis();
@@ -67,6 +68,8 @@ public class ReminderExtension implements IExtension, IMapChangeListener {
     public ReminderExtension(ReminderHook reminderController, final NodeModel node) {
         this.reminderController = reminderController;
         this.node = node;
+        this.reminderController.getModeController().getMapController().addUIMapChangeListener(this);
+        this.reminderController.getModeController().getMapController().addMapLifeCycleListener(this);
     }
 
     public NodeModel getNode() {
@@ -252,5 +255,11 @@ public class ReminderExtension implements IExtension, IMapChangeListener {
     @Override
     public void onPreNodeMoved(NodeMoveEvent nodeMoveEvent) {
         displayStateIcon(nodeMoveEvent.oldParent, null);
+    }
+
+    @Override
+    public void onRemove(MapModel map) {
+        this.reminderController.getModeController().getMapController().removeMapChangeListener(this);
+        this.reminderController.getModeController().getMapController().removeMapLifeCycleListener(this);
     }
 }

--- a/freeplane/src/main/java/org/freeplane/view/swing/features/time/mindmapmode/ReminderHook.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/features/time/mindmapmode/ReminderHook.java
@@ -241,7 +241,6 @@ public class ReminderHook extends PersistentNodeHook implements IExtension {
 	public void add(final NodeModel node, final IExtension extension) {
 		final ReminderExtension reminder = (ReminderExtension) extension;
 		reminder.scheduleTimer();
-		modeController.getMapController().addUIMapChangeListener(reminder);
 		super.add(node, extension);
 	}
 


### PR DESCRIPTION
Kind of like memory leakage, if a map has many blinking nodes, after several open and close operations the map change listener list would be blown up.