### PR TITLE
emulate vim-like simple keyboard navigation

### DIFF
--- a/freeplane/src/editor/resources/translations/Resources_zh_CN.properties
+++ b/freeplane/src/editor/resources/translations/Resources_zh_CN.properties
@@ -1134,6 +1134,7 @@ OptionPanel.el__max_default_window_width=\u9ED8\u8BA4\u7A97\u53E3\u6700\u5927\u5
 OptionPanel.el__min_default_window_height=\u9ED8\u8BA4\u7A97\u53E3\u6700\u5C0F\u9AD8\u5EA6
 OptionPanel.el__min_default_window_width=\u9ED8\u8BA4\u7A97\u53E3\u6700\u5C0F\u5BBD\u5EA6
 OptionPanel.el__position_window_below_node=\u8282\u70B9\u4E0B\u4F4D\u7F6E\u7A97\u53E3
+OptionPanel.EMULATE_VIM_NAV=\u6A21\u62DFVIM\u5BFC\u822A
 OptionPanel.en=\u82F1\u8BED
 OptionPanel.enforceModalEditorDialogs=\u5F3A\u5236\u4F7F\u7528\u6A21\u6001\u5BF9\u8BDD\u6846
 OptionPanel.enforceModalEditorDialogs.tooltip=\u975E\u6A21\u6001\u5BF9\u8BDD\u6846\u5BF9\u67D0\u4E9B\u7A97\u53E3\u7BA1\u7406\u5668\u4F1A\u6709\u95EE\u9898

--- a/freeplane/src/editor/resources/translations/Resources_zh_TW.properties
+++ b/freeplane/src/editor/resources/translations/Resources_zh_TW.properties
@@ -1111,6 +1111,7 @@ OptionPanel.el__max_default_window_width=\u6700\u5927\u8996\u7A97\u5BEC\u5EA6
 OptionPanel.el__min_default_window_height=\u6700\u5C0F\u8996\u7A97\u9AD8\u5EA6
 OptionPanel.el__min_default_window_width=\u6700\u5C0F\u8996\u7A97\u5BEC\u5EA6
 OptionPanel.el__position_window_below_node=\u8996\u7A97\u5728\u7BC0\u9EDE\u4E0B\u65B9
+OptionPanel.EMULATE_VIM_NAV=\u6A21\u64ECVIM\u5C0E\u822A
 OptionPanel.en=English (\u82F1\u6587)
 OptionPanel.Environment=\u74B0\u5883\u8A2D\u5B9A
 OptionPanel.es=Espa\u00F1ol / Castellano (\u897F\u73ED\u7259\u6587 / \u5361\u65AF\u63D0\u723E\u6587)

--- a/freeplane/src/external/resources/xml/preferences.xml
+++ b/freeplane/src/external/resources/xml/preferences.xml
@@ -210,6 +210,7 @@
 					<choice value="IGNORE" />
 					<choice value="ADD_SIBLING" />
 					<choice value="ADD_CHILD" />
+					<choice value="EMULATE_VIM_NAV" />
 				</combo>
 				<boolean name="copyFormatToNewSibling"/>
 				<boolean name="copyFormatToNewChild"/>

--- a/freeplane/src/main/java/org/freeplane/core/ui/IEditHandler.java
+++ b/freeplane/src/main/java/org/freeplane/core/ui/IEditHandler.java
@@ -23,6 +23,6 @@ package org.freeplane.core.ui;
 import java.awt.event.KeyEvent;
 
 public interface IEditHandler {
-	public enum FirstAction{EDIT_CURRENT, ADD_SIBLING, ADD_CHILD, IGNORE}
+	public enum FirstAction{EDIT_CURRENT, ADD_SIBLING, ADD_CHILD, IGNORE, EMULATE_VIM_NAV}
 	void edit(KeyEvent e, FirstAction keyTypeAction, boolean editLong);
 }

--- a/freeplane/src/main/java/org/freeplane/view/swing/ui/DefaultNodeKeyListener.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/ui/DefaultNodeKeyListener.java
@@ -7,16 +7,20 @@ import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
 
 import org.freeplane.core.resources.ResourceController;
+import org.freeplane.core.ui.AFreeplaneAction;
 import org.freeplane.core.ui.ActionAcceleratorManager;
 import org.freeplane.core.ui.ControllerPopupMenuListener;
 import org.freeplane.core.ui.IEditHandler;
 import org.freeplane.core.ui.IEditHandler.FirstAction;
 import org.freeplane.core.util.Compat;
+import org.freeplane.features.map.MapController;
 import org.freeplane.features.map.NodeModel;
 import org.freeplane.features.mode.Controller;
 import org.freeplane.features.mode.ModeController;
+import org.freeplane.features.text.mindmapmode.MTextController;
 import org.freeplane.view.swing.map.MainView;
 import org.freeplane.view.swing.map.MapView;
+import org.freeplane.view.swing.map.MapViewController;
 import org.freeplane.view.swing.map.NodeView;
 
 /**
@@ -127,7 +131,12 @@ public class DefaultNodeKeyListener implements KeyListener {
 		final String keyTypeActionString = ResourceController.getResourceController().getProperty("key_type_action",
 		    FirstAction.EDIT_CURRENT.toString());
 		final FirstAction keyTypeAction = FirstAction.valueOf(keyTypeActionString);
-		if (!FirstAction.IGNORE.equals(keyTypeAction)) {
+		if (FirstAction.IGNORE.equals(keyTypeAction)) {
+		    return;
+		}
+		if (FirstAction.EMULATE_VIM_NAV.equals(keyTypeAction)) {
+            emulateVimNavigation(e);
+		} else {
 			if (! isActionEvent(e)) {
 				if (editHandler != null) {
 					editHandler.edit(e, keyTypeAction, false);
@@ -136,6 +145,90 @@ public class DefaultNodeKeyListener implements KeyListener {
 			}
 		}
 	}
+
+    private void emulateVimNavigation(KeyEvent e) {
+        final MapViewController controller = (MapViewController) Controller.getCurrentController().getMapViewManager();
+        final MapView mapView = (MapView) controller.getMapViewComponent();
+        if (mapView == null || SwingUtilities.isDescendingFrom(mapView, e.getComponent())) {
+            return;
+        }
+        final ActionAcceleratorManager acceleratorManager = ResourceController.getResourceController()
+                .getAcceleratorManager();
+        if (acceleratorManager.canProcessKeyEvent(e)) {
+            return;
+        }
+        if ((e.isAltDown() || e.isControlDown() || e.isMetaDown())) {
+            return;
+        }
+
+        final boolean continious = e.isShiftDown();
+        boolean consumed = true;
+        switch (e.getKeyChar()) {
+        case 'h':
+            consumed = mapView.selectLeft(continious);
+            break;
+        case 'j':
+            consumed = mapView.selectDown(continious);
+            break;
+        case 'k':
+            consumed = mapView.selectUp(continious);
+            break;
+        case 'l':
+            consumed = mapView.selectRight(continious);
+            break;
+        case 'H':
+            mapView.scrollBy(-20, 0);
+            break;
+        case 'J':
+            mapView.scrollBy(0, 20);
+            break;
+        case 'K':
+            mapView.scrollBy(0, -20);
+            break;
+        case 'L':
+            mapView.scrollBy(20, 0);
+            break;
+        case '-':
+            controller.zoomOut();
+            break;
+        case '+':
+            controller.zoomIn();
+            break;
+        case 'i':
+            final MTextController textController = MTextController.getController();
+            textController.getEventQueue().activate();
+            textController.edit(FirstAction.EDIT_CURRENT, false);
+            break;
+        case 'n':
+            final AFreeplaneAction findNextAction = Controller.getCurrentModeController()
+                    .getAction("QuickFindAction." + MapController.Direction.FORWARD);
+            if (findNextAction != null) {
+                findNextAction.actionPerformed(null);
+            }
+            break;
+        case 'N':
+            final AFreeplaneAction findPrevAction = Controller.getCurrentModeController()
+                    .getAction("QuickFindAction." + MapController.Direction.BACK);
+            if (findPrevAction != null) {
+                findPrevAction.actionPerformed(null);
+            }
+            break;
+        case ':':
+            final AFreeplaneAction cmdSearchAction = Controller.getCurrentModeController()
+                    .getAction("CommandSearchAction");
+            if (cmdSearchAction != null) {
+                cmdSearchAction.actionPerformed(null);
+            }
+            break;
+        default:
+            consumed = false;
+            break;
+        }
+
+        if (consumed) {
+            e.consume();
+        }
+    }
 
 	private boolean isActionEvent(final KeyEvent e) {
 	    return e.isActionKey() || isControlCharacter(e.getKeyChar());

--- a/freeplane/src/viewer/resources/translations/Resources_en.properties
+++ b/freeplane/src/viewer/resources/translations/Resources_en.properties
@@ -1141,6 +1141,7 @@ OptionPanel.el__max_default_window_width=Max default window width
 OptionPanel.el__min_default_window_height=Min default window height
 OptionPanel.el__min_default_window_width=Min default window width
 OptionPanel.el__position_window_below_node=Position window below node
+OptionPanel.EMULATE_VIM_NAV=Emulate VIM navigation
 OptionPanel.en=English / English
 OptionPanel.enforceModalEditorDialogs=Enforce modal editor dialogs
 OptionPanel.enforceModalEditorDialogs.tooltip=Non-modal dialogs can make troubles on some window managers


### PR DESCRIPTION
Inspired by:
https://sourceforge.net/p/freeplane/discussion/758437/thread/e904441d/?limit=25

Currently supported key mapping in this mode:

1. 'h', 'j', 'k', 'l' for node selection
2. 'H', 'J', 'K', 'L' for map scrolling
3. '+', '-' for zooming
4. 'i' for edit current
5. 'n', 'N' for next/prev search
6. ':' for command search

Not supported:

1. 'o', 'O' for new node, we have 'Enter', 'Insert'
2. 'ESC' for NORMAL MODE, don't need this
3. '/' for search, we have ctrl+F

Other useful mapping could be added in the future.