### PR TITLE
Auto-select the first choice in the command search dialog

### DIFF
--- a/freeplane/src/main/java/org/freeplane/features/commandsearch/CommandSearchDialog.java
+++ b/freeplane/src/main/java/org/freeplane/features/commandsearch/CommandSearchDialog.java
@@ -343,6 +343,10 @@ public class CommandSearchDialog extends JDialog
         }
         UpdateableListModel<SearchItem> model = new UpdateableListModel<>(matches);
         resultList.setModel(model);
+
+        if (resultList.getModel().getSize() > 0) {
+            resultList.setSelectedIndex(0);
+        }
     }
 
     @Override


### PR DESCRIPTION
Hi,

When searching for a command, it's convenient to have the first line selected automatically after the matches were updated. This way you don't have to press the down arrow first, you can just press enter to execute the selected item.