### PR TITLE
Bugfix/overview interactions

### DIFF
--- a/freeplane/src/main/java/org/freeplane/view/swing/map/MapViewScrollPane.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/MapViewScrollPane.java
@@ -85,14 +85,10 @@ public class MapViewScrollPane extends JScrollPane implements IFreeplaneProperty
         public void scrollRectToVisible(Rectangle newContentRectangle) {
         	final Rectangle hiddenArea = hiddenAreaSupplier.getHiddenArea();
         	if(hiddenArea.width != 0 && hiddenArea.height != 0) {
-        		Point viewportLocation = new Point(0, 0);
-        		UITools.convertPointToAncestor(this, viewportLocation, JScrollPane.class);
-        		hiddenArea.x -= viewportLocation.x;
-        		hiddenArea.y -= viewportLocation.y;
         		final boolean isHiddenAreaAtTheLeft = hiddenArea.x == 0;
 				final boolean isHiddenAreaAtTheTop = hiddenArea.y == 0;
-				final boolean isHiddenAreaAtTheRight = hiddenArea.x + hiddenArea.width == getWidth();
-				final boolean isHiddenAreaAtTheBottom = hiddenArea.y + hiddenArea.height == getHeight();
+				final boolean isHiddenAreaAtTheRight = hiddenArea.x + hiddenArea.width == getParent().getWidth();
+				final boolean isHiddenAreaAtTheBottom = hiddenArea.y + hiddenArea.height == getParent().getHeight();
 				if(isHiddenAreaAtTheLeft || isHiddenAreaAtTheRight
 						|| isHiddenAreaAtTheTop || isHiddenAreaAtTheBottom) {
         			final Rectangle newContentRectangleWithHiddenArea = new Rectangle(newContentRectangle);

--- a/freeplane/src/main/java/org/freeplane/view/swing/map/MapViewScrollPane.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/MapViewScrollPane.java
@@ -87,8 +87,8 @@ public class MapViewScrollPane extends JScrollPane implements IFreeplaneProperty
         	if(hiddenArea.width != 0 && hiddenArea.height != 0) {
         		final boolean isHiddenAreaAtTheLeft = hiddenArea.x == 0;
 				final boolean isHiddenAreaAtTheTop = hiddenArea.y == 0;
-				final boolean isHiddenAreaAtTheRight = hiddenArea.x + hiddenArea.width == getParent().getWidth();
-				final boolean isHiddenAreaAtTheBottom = hiddenArea.y + hiddenArea.height == getParent().getHeight();
+				final boolean isHiddenAreaAtTheRight = hiddenArea.x + hiddenArea.width == getWidth();
+				final boolean isHiddenAreaAtTheBottom = hiddenArea.y + hiddenArea.height == getHeight();
 				if(isHiddenAreaAtTheLeft || isHiddenAreaAtTheRight
 						|| isHiddenAreaAtTheTop || isHiddenAreaAtTheBottom) {
         			final Rectangle newContentRectangleWithHiddenArea = new Rectangle(newContentRectangle);

--- a/freeplane/src/main/java/org/freeplane/view/swing/map/overview/MapViewPane.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/overview/MapViewPane.java
@@ -19,7 +19,6 @@ import org.freeplane.api.LengthUnit;
 import org.freeplane.api.Quantity;
 import org.freeplane.core.resources.IFreeplanePropertyListener;
 import org.freeplane.core.resources.ResourceController;
-import org.freeplane.core.ui.components.UITools;
 import org.freeplane.features.map.IMapChangeListener;
 import org.freeplane.features.map.MapChangeEvent;
 import org.freeplane.features.mode.Controller;
@@ -263,7 +262,6 @@ public class MapViewPane extends JPanel implements IFreeplanePropertyListener, I
         default:
         	throw new RuntimeException("All cases handled above");
         }
-        UITools.convertPointToAncestor(viewPort, location, JScrollPane.class);
         bounds.setLocation(location);
     }
 

--- a/freeplane/src/main/java/org/freeplane/view/swing/map/overview/MapViewPane.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/overview/MapViewPane.java
@@ -258,7 +258,7 @@ public class MapViewPane extends JPanel implements IFreeplanePropertyListener, I
         	location = new Point(right - bounds.x  - bounds.width, bounds.y);
             break;
         case NORTH_WEST:
-        	location = new Point(0, 0);
+		location = new Point(bounds.x, bounds.y);
             break;
         default:
         	throw new RuntimeException("All cases handled above");

--- a/freeplane/src/main/java/org/freeplane/view/swing/map/overview/MapViewPane.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/overview/MapViewPane.java
@@ -268,7 +268,23 @@ public class MapViewPane extends JPanel implements IFreeplanePropertyListener, I
 	@Override
 	public Rectangle getHiddenArea() {
 		if (isMapOverviewVisible) {
-			return mapOverviewPanel.getBounds();
+			Rectangle overviewBounds = mapOverviewPanel.getBounds();
+			int width = getWidth();
+			int height = getHeight();
+			if (overviewBounds.x < width - overviewBounds.x - overviewBounds.width) {
+				overviewBounds.width += overviewBounds.x;
+				overviewBounds.x = 0;
+			} else {
+				overviewBounds.width = width - overviewBounds.x;
+			}
+			if (overviewBounds.y < height - overviewBounds.y - overviewBounds.height) {
+				overviewBounds.height += overviewBounds.y;
+				overviewBounds.y = 0;
+			} else {
+				overviewBounds.height = height - overviewBounds.y;
+			}
+
+			return overviewBounds;
 		} else
 			return MapViewScrollPane.EMPTY_RECTANGLE;
 	}


### PR DESCRIPTION
1. the first commit is for a confirmed bug (fix the bounds location when overview is attached to NW, otherwise it cannot be moved)
2.  the second commit is for overview size resetting (the original design is when attaching to the origin, second double click reset its size), but the fix is in doubt. Please give feedback if there's any problem.
3. the third commit is an improvement which can handle the case when overview is not attached to the very origin (0, 0) in its corresponding corner, which means in the original implementation, if the overview is moved away from the corner, the uncovering will not work. The hidden area is extended to the smaller corner relative to the underlying mapview so the original algorithm will think that the whole extended area is hidden, which makes the original algorithm works again.

Thanks for the uncovering implementation @dpolivaev .