### PR TITLE
Fix some deprecation API warnings

### DIFF
--- a/JOrtho_0.4_freeplane/src/test/java/com/inet/jorthotests/EventTest.java
+++ b/JOrtho_0.4_freeplane/src/test/java/com/inet/jorthotests/EventTest.java
@@ -9,7 +9,6 @@ package com.inet.jorthotests;
 import javax.swing.JMenu;
 import javax.swing.JRadioButtonMenuItem;
 
-import junit.framework.Assert;
 import junit.framework.TestCase;
 
 import com.inet.jortho.SpellChecker;
@@ -24,15 +23,15 @@ public class EventTest extends TestCase {
 	 */
 	private void assertEquals(final String description, final JRadioButtonMenuItem item1,
 	                          final JRadioButtonMenuItem item2) {
-		Assert.assertEquals(description + ": Name", item1.getName(), item2.getName());
-		Assert.assertEquals(description + ": Selected", item1.isSelected(), item2.isSelected());
+		assertEquals(description + ": Name", item1.getName(), item2.getName());
+		assertEquals(description + ": Selected", item1.isSelected(), item2.isSelected());
 	}
 
 	public void testChangeLanguage() throws Exception {
 		final JMenu menu1 = SpellChecker.createLanguagesMenu();
 		final JMenu menu2 = SpellChecker.createLanguagesMenu();
-		Assert.assertEquals("Menucount", menu1.getItemCount(), menu2.getItemCount());
-		Assert.assertTrue("2 languages requied:" + menu1.getItemCount(), menu1.getItemCount() >= 2);
+		assertEquals("Menucount", menu1.getItemCount(), menu2.getItemCount());
+		assertTrue("2 languages requied:" + menu1.getItemCount(), menu1.getItemCount() >= 2);
 		final JRadioButtonMenuItem item1_1 = (JRadioButtonMenuItem) menu1.getItem(0);
 		final JRadioButtonMenuItem item1_2 = (JRadioButtonMenuItem) menu1.getItem(1);
 		final JRadioButtonMenuItem item2_1 = (JRadioButtonMenuItem) menu2.getItem(0);
@@ -42,21 +41,21 @@ public class EventTest extends TestCase {
 		//Change the selected language
 		JRadioButtonMenuItem notSelected = item1_1.isSelected() ? item1_2 : item1_1;
 		JRadioButtonMenuItem selected = item1_1.isSelected() ? item1_1 : item1_2;
-		Assert.assertFalse("Selected", notSelected.isSelected());
-		Assert.assertTrue("Selected", selected.isSelected());
+		assertFalse("Selected", notSelected.isSelected());
+		assertTrue("Selected", selected.isSelected());
 		notSelected.doClick(0);
-		Assert.assertTrue("Selected", notSelected.isSelected());
-		Assert.assertFalse("Selected", selected.isSelected());
+		assertTrue("Selected", notSelected.isSelected());
+		assertFalse("Selected", selected.isSelected());
 		assertEquals("Item 1", item1_1, item2_1);
 		assertEquals("Item 2", item1_2, item2_2);
 		Thread.sleep(10); // for loading thread
 		notSelected = item2_1.isSelected() ? item2_2 : item2_1;
 		selected = item2_1.isSelected() ? item2_1 : item2_2;
-		Assert.assertFalse("Selected", notSelected.isSelected());
-		Assert.assertTrue("Selected", selected.isSelected());
+		assertFalse("Selected", notSelected.isSelected());
+		assertTrue("Selected", selected.isSelected());
 		notSelected.doClick(0);
-		Assert.assertTrue("Selected", notSelected.isSelected());
-		Assert.assertFalse("Selected", selected.isSelected());
+		assertTrue("Selected", notSelected.isSelected());
+		assertFalse("Selected", selected.isSelected());
 		assertEquals("Item 1", item1_1, item2_1);
 		assertEquals("Item 2", item1_2, item2_2);
 		Thread.sleep(10); // for loading thread

--- a/JOrtho_0.4_freeplane/src/test/java/com/inet/jorthotests/MemoryTest.java
+++ b/JOrtho_0.4_freeplane/src/test/java/com/inet/jorthotests/MemoryTest.java
@@ -10,7 +10,6 @@ import java.awt.Toolkit;
 
 import javax.swing.JTextPane;
 
-import junit.framework.Assert;
 import junit.framework.TestCase;
 
 import com.inet.jortho.SpellChecker;
@@ -31,7 +30,7 @@ public class MemoryTest extends TestCase {
 		}
 		final long memoryAfter = usedMemory();
 		if (memoryBefore + 100000 < memoryAfter) {
-			Assert.fail("Memory Leak SpellChecker.createLanguagesMenu. memory before:" + (memoryBefore / 1024)
+			fail("Memory Leak SpellChecker.createLanguagesMenu. memory before:" + (memoryBefore / 1024)
 			        + " KB  memory after:" + (memoryAfter / 1024) + " KB");
 		}
 	}
@@ -62,7 +61,7 @@ public class MemoryTest extends TestCase {
 		}
 		final long memoryAfter = usedMemory();
 		if (memoryBefore + 1000000 < memoryAfter) {
-			Assert.fail("Memory Leak SpellChecker.register. memory before:" + (memoryBefore / 1024)
+			fail("Memory Leak SpellChecker.register. memory before:" + (memoryBefore / 1024)
 			        + " KB  memory after:" + (memoryAfter / 1024) + " KB");
 		}
 	}

--- a/freeplane/src/main/java/org/freeplane/features/mode/Controller.java
+++ b/freeplane/src/main/java/org/freeplane/features/mode/Controller.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.freeplane.core.extension.ExtensionContainer;
 import org.freeplane.core.extension.IExtension;
 import org.freeplane.core.resources.OptionPanelController;
@@ -244,13 +243,12 @@ public class Controller extends AController implements FreeplaneActions, IMapLif
 				waiting(waitFor, proc);
 			}
 
-			private void waiting(boolean waitFor, Process proc)
-					throws IOExceptionWithCause {
+			private void waiting(boolean waitFor, Process proc) throws IOException {
 				if(waitFor) {
 					try {
 						proc.waitFor();
 					} catch (InterruptedException e) {
-						throw new IOExceptionWithCause(e);
+						throw new IOException(e);
 					}
 				}
 			}

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/MenuBuilderIntegrationTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/MenuBuilderIntegrationTest.java
@@ -2,7 +2,7 @@ package org.freeplane.core.ui.menubuilders;
 
 import static org.freeplane.core.ui.menubuilders.generic.PhaseProcessor.Phase.ACTIONS;
 import static org.freeplane.core.ui.menubuilders.generic.PhaseProcessor.Phase.UI;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/XmlEntryStructureBuilderTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/XmlEntryStructureBuilderTest.java
@@ -1,8 +1,8 @@
 package org.freeplane.core.ui.menubuilders;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
 
 import org.freeplane.core.ui.menubuilders.generic.Entry;
 import org.junit.Test;

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/action/AcceleratorBuilderTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/action/AcceleratorBuilderTest.java
@@ -1,6 +1,6 @@
 package org.freeplane.core.ui.menubuilders.action;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/action/ActionFinderTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/action/ActionFinderTest.java
@@ -1,6 +1,6 @@
 package org.freeplane.core.ui.menubuilders.action;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +26,7 @@ public class ActionFinderTest {
 		final ActionFinder actionFinder = new ActionFinder(freeplaneActions);
 		actionFinder.visit(entry);
 		
-		assertThat((AFreeplaneAction) new EntryAccessor().getAction(entry), CoreMatchers.equalTo(someAction));
+		assertThat(new EntryAccessor().getAction(entry), CoreMatchers.equalTo(someAction));
 	}
 
 	@Test

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/action/ComponentBuilderTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/action/ComponentBuilderTest.java
@@ -1,14 +1,13 @@
 package org.freeplane.core.ui.menubuilders.action;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import java.awt.Component;
 
 import javax.swing.JPanel;
 
 import org.freeplane.core.ui.menubuilders.generic.Entry;
 import org.freeplane.core.ui.menubuilders.generic.EntryAccessor;
-import org.freeplane.core.ui.menubuilders.menu.ComponentProvider;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ComponentBuilderTest {
@@ -16,13 +15,8 @@ public class ComponentBuilderTest {
 	public void testName() throws Exception {
 		final Entry entry = new Entry();
 		final Component testComponent = new JPanel();
-		final ComponentBuilder builder = new ComponentBuilder(new ComponentProvider() {
-			@Override
-			public Component createComponent(Entry entry) {
-				return testComponent;
-			}
-		});
+		final ComponentBuilder builder = new ComponentBuilder(entry1 -> testComponent);
 		builder.visit(entry);
-		Assert.assertThat(new EntryAccessor().getComponent(entry), CoreMatchers.<Object> equalTo(testComponent));
+		assertThat(new EntryAccessor().getComponent(entry), CoreMatchers.<Object> equalTo(testComponent));
 	}
 }

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/action/EntriesForActionTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/action/EntriesForActionTest.java
@@ -2,7 +2,7 @@ package org.freeplane.core.ui.menubuilders.action;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.Collection;
@@ -27,7 +27,7 @@ public class EntriesForActionTest {
 		final Entry actionEntry = new Entry();
 		entriesForAction.registerEntry(action, actionEntry);
 		Collection<Entry> entries = entriesForAction.entries(action);
-		assertThat(entries, equalTo((Collection<Entry>) asList(actionEntry)));
+		assertThat(entries, equalTo(asList(actionEntry)));
 	}
 
 	@Test
@@ -39,7 +39,7 @@ public class EntriesForActionTest {
 		entriesForAction.registerEntry(action, actionEntry1);
 		entriesForAction.registerEntry(action, actionEntry2);
 		Collection<Entry> entries = entriesForAction.entries(action);
-		assertThat(entries, equalTo((Collection<Entry>) asList(actionEntry1, actionEntry2)));
+		assertThat(entries, equalTo(asList(actionEntry1, actionEntry2)));
 	}
 
 	@Test

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/generic/EntryAccessorTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/generic/EntryAccessorTest.java
@@ -1,6 +1,7 @@
 package org.freeplane.core.ui.menubuilders.generic;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -9,7 +10,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JSeparator;
 
 import org.freeplane.core.ui.AFreeplaneAction;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,7 +29,7 @@ public class EntryAccessorTest {
 	public void getsTextFromEntryAttributeText() throws Exception {
 		entry.setAttribute("text", "entry text");
 		final String entryText = entryAccessor.getText(entry);
-		Assert.assertThat(entryText, equalTo("entry text"));
+		assertThat(entryText, equalTo("entry text"));
 	}
 	
 	@Test
@@ -37,7 +37,7 @@ public class EntryAccessorTest {
 		entry.setAttribute("textKey", "entry text key");
 		when(resourceAccessor.getRawText("entry text key")).thenReturn("entry text");
 		final String entryText = entryAccessor.getText(entry);
-		Assert.assertThat(entryText, equalTo("entry text"));
+		assertThat(entryText, equalTo("entry text"));
 	}
 
 	@Test
@@ -45,14 +45,14 @@ public class EntryAccessorTest {
 		final Icon icon = new ImageIcon();
 		entry.setAttribute(EntryAccessor.ICON_INSTANCE, icon);
 		final Icon entryIcon = entryAccessor.getIcon(entry);
-		Assert.assertThat(entryIcon, equalTo(icon));
+		assertThat(entryIcon, equalTo(icon));
 	}
 
 	@Test
 	public void setsTextToEntryAttributeText() throws Exception {
 		entryAccessor.setText(entry, "entry text");
 		final String entryText = entryAccessor.getText(entry);
-		Assert.assertThat(entryText, equalTo("entry text"));
+		assertThat(entryText, equalTo("entry text"));
 	}
 
 	@Test
@@ -60,7 +60,7 @@ public class EntryAccessorTest {
 		final Icon icon = new ImageIcon();
 		entryAccessor.setIcon(entry, icon);
 		final Icon entryIcon = entryAccessor.getIcon(entry);
-		Assert.assertThat(entryIcon, equalTo(icon));
+		assertThat(entryIcon, equalTo(icon));
 	}
 
 	@Test
@@ -68,7 +68,7 @@ public class EntryAccessorTest {
 		final AFreeplaneAction action = mock(AFreeplaneAction.class);
 		entryAccessor.setAction(entry, action);
 		final AFreeplaneAction entryAction = entryAccessor.getAction(entry);
-		Assert.assertThat(entryAction, equalTo(action));
+		assertThat(entryAction, equalTo(action));
 	}
 
 	@Test
@@ -78,8 +78,8 @@ public class EntryAccessorTest {
 		entryAccessor.addChildAction(entry, action);
 		final Entry actionEntry = entry.getChild(0);
 		final AFreeplaneAction entryAction = entryAccessor.getAction(actionEntry);
-		Assert.assertThat(actionEntry.getName(), equalTo("key"));
-		Assert.assertThat(entryAction, equalTo(action));
+		assertThat(actionEntry.getName(), equalTo("key"));
+		assertThat(entryAction, equalTo(action));
 	}
 
 	@Test
@@ -87,7 +87,7 @@ public class EntryAccessorTest {
 		entryAccessor.setComponent(entry, new JSeparator());
 		
 		final String entryText = entryAccessor.getLocationDescription(entry);
-		Assert.assertThat(entryText, equalTo(""));
+		assertThat(entryText, equalTo(""));
 	}
 
 	@Test
@@ -97,7 +97,7 @@ public class EntryAccessorTest {
 		entryAccessor.setComponent(entry, new JSeparator());
 		
 		final String entryText = entryAccessor.getLocationDescription(entry);
-		Assert.assertThat(entryText, equalTo(text));
+		assertThat(entryText, equalTo(text));
 	}
 
 	@Test
@@ -111,6 +111,6 @@ public class EntryAccessorTest {
 		entryAccessor.setComponent(parent, new JSeparator());
 
 		final String entryText = entryAccessor.getLocationDescription(entry);
-		Assert.assertThat(entryText, equalTo("parent -> entry"));
+		assertThat(entryText, equalTo("parent -> entry"));
 	}
 }

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/generic/EntryNavigatorTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/generic/EntryNavigatorTest.java
@@ -1,7 +1,7 @@
 package org.freeplane.core.ui.menubuilders.generic;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collections;
 

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/generic/EntryTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/generic/EntryTest.java
@@ -2,7 +2,7 @@ package org.freeplane.core.ui.menubuilders.generic;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.awt.Component;

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/generic/PhaseProcessorTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/generic/PhaseProcessorTest.java
@@ -3,6 +3,7 @@ package org.freeplane.core.ui.menubuilders.generic;
 import static org.freeplane.core.ui.menubuilders.generic.PhaseProcessor.Phase.ACCELERATORS;
 import static org.freeplane.core.ui.menubuilders.generic.PhaseProcessor.Phase.ACTIONS;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -10,7 +11,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.InOrder;
 
@@ -59,7 +59,7 @@ public class PhaseProcessorTest {
 	public void returnsPhase() throws Exception {
 		RecursiveMenuStructureProcessor builder = mock(RecursiveMenuStructureProcessor.class);
 		final PhaseProcessor phasedBuilder = new PhaseProcessor().withPhase(ACTIONS, builder);
-		Assert.assertThat(phasedBuilder.phase(ACTIONS), equalTo(builder));
+		assertThat(phasedBuilder.phase(ACTIONS), equalTo(builder));
 	}
 
 	@Test

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/generic/RecursiveMenuStructureProcessorTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/generic/RecursiveMenuStructureProcessorTest.java
@@ -2,7 +2,7 @@ package org.freeplane.core.ui.menubuilders.generic;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/JComponentRemoverTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/JComponentRemoverTest.java
@@ -2,6 +2,7 @@ package org.freeplane.core.ui.menubuilders.menu;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.awt.Container;
 
@@ -12,7 +13,6 @@ import javax.swing.JPanel;
 import org.freeplane.core.ui.MenuSplitter;
 import org.freeplane.core.ui.menubuilders.generic.Entry;
 import org.freeplane.core.ui.menubuilders.generic.EntryAccessor;
-import org.junit.Assert;
 import org.junit.Test;
 
 
@@ -27,7 +27,7 @@ public class JComponentRemoverTest {
 		new EntryAccessor().setComponent(entry, entryComponent);
 		componentRemover.visit(entry);
 		
-		Assert.assertThat(entryComponent.getParent(), nullValue(Container.class));
+		assertThat(entryComponent.getParent(), nullValue(Container.class));
 	}
 
 	@Test
@@ -48,6 +48,6 @@ public class JComponentRemoverTest {
 		menuSplitter.addMenuComponent(parent, entryComponent);
 		new EntryAccessor().setComponent(entry, entryComponent);
 		componentRemover.visit(entry);
-		Assert.assertThat(parent.getPopupMenu().getComponentCount(), equalTo(1));
+		assertThat(parent.getPopupMenu().getComponentCount(), equalTo(1));
 	}
 }

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/JMenuItemBuilderTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/JMenuItemBuilderTest.java
@@ -1,15 +1,14 @@
 package org.freeplane.core.ui.menubuilders.menu;
 
-import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.awt.Container;
+import java.util.Collections;
 import javax.swing.Action;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -30,7 +29,6 @@ import org.freeplane.core.ui.menubuilders.generic.EntryPopupListener;
 import org.freeplane.core.ui.menubuilders.generic.ResourceAccessor;
 import org.freeplane.core.util.Compat;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -94,7 +92,7 @@ public class JMenuItemBuilderTest {
 		JMenuItem item = (JMenuItem)new EntryAccessor().getComponent(actionEntry);
 
 		assertThatMenuItemHasCorrectAction(item);
-		assertThat(item.getParent(), CoreMatchers.<Container>equalTo(menu.getPopupMenu()));
+		assertThat(item.getParent(), CoreMatchers.equalTo(menu.getPopupMenu()));
 	}
 
 	@Test
@@ -106,7 +104,7 @@ public class JMenuItemBuilderTest {
 		when(accelerators.getAccelerator(action)).thenReturn(keyStroke);
 		menuActionGroupBuilder.visit(actionEntry);
 		JMenuItem item = (JMenuItem) new EntryAccessor().getComponent(actionEntry);
-		Assert.assertThat(item.getAccelerator(), equalTo(keyStroke));
+		assertThat(item.getAccelerator(), equalTo(keyStroke));
 	}
 
 	@Test
@@ -120,21 +118,21 @@ public class JMenuItemBuilderTest {
 
 		final AccelerateableAction itemAction = (AccelerateableAction) item.getAction();
 		assertThat(itemAction.getOriginalAction(), CoreMatchers.<Action> equalTo(action));
-		assertThat(item.getParent(), CoreMatchers.<Container>equalTo(menu.getPopupMenu()));
+		assertThat(item.getParent(), CoreMatchers.equalTo(menu.getPopupMenu()));
 	}
 	
 	@Test
 	public void createsMenuSeparator() {
 		new EntryAccessor().setComponent(menuEntry, menu);
 		Entry separatorEntry = new Entry();
-		separatorEntry.setBuilders(asList("separator"));
+		separatorEntry.setBuilders(Collections.singletonList("separator"));
 		menuEntry.addChild(separatorEntry);
 		
 		menuActionGroupBuilder.visit(separatorEntry);
 
 		JPopupMenu.Separator separator = (JPopupMenu.Separator)new EntryAccessor().getComponent(separatorEntry);
 
-		assertThat(separator.getParent(), CoreMatchers.<Container>equalTo(menu.getPopupMenu()));
+		assertThat(separator.getParent(), CoreMatchers.equalTo(menu.getPopupMenu()));
 	}
 
 	@Test
@@ -148,7 +146,7 @@ public class JMenuItemBuilderTest {
 		menuActionGroupBuilder.visit(menuEntry);
 
 		JMenu item = (JMenu)new EntryAccessor().getComponent(menuEntry);
-		assertThat(item.getParent(), CoreMatchers.<Container>equalTo(parentMenu.getPopupMenu()));
+		assertThat(item.getParent(), CoreMatchers.equalTo(parentMenu.getPopupMenu()));
 	}
 
 	@Test
@@ -162,7 +160,7 @@ public class JMenuItemBuilderTest {
 		menuActionGroupBuilder.visit(menuEntry);
 
 		JMenu item = (JMenu)new EntryAccessor().getComponent(menuEntry);
-		assertThat(item.getParent(), CoreMatchers.<Container>equalTo(parentMenu));
+		assertThat(item.getParent(), CoreMatchers.equalTo(parentMenu));
 	}
 
 	@Test
@@ -227,7 +225,7 @@ public class JMenuItemBuilderTest {
 	@Test
 	public void whenNoPopupMenuBecomesVisible_PopupListenerIsNotCalled() {
 		menuActionGroupBuilder.visit(menuEntry);
-		verify(popupListener, never()).childEntriesWillBecomeVisible(Mockito.<Entry> anyObject());
+		verify(popupListener, never()).childEntriesWillBecomeVisible(Mockito.any());
 	}
 
 	@Test

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/JMenuRadioGroupBuilderTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/JMenuRadioGroupBuilderTest.java
@@ -1,6 +1,7 @@
 package org.freeplane.core.ui.menubuilders.menu;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -12,7 +13,6 @@ import org.freeplane.core.ui.menubuilders.generic.Entry;
 import org.freeplane.core.ui.menubuilders.generic.EntryAccessor;
 import org.freeplane.core.ui.menubuilders.generic.EntryPopupListener;
 import org.freeplane.core.ui.menubuilders.generic.ResourceAccessor;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -50,6 +50,6 @@ public class JMenuRadioGroupBuilderTest {
 	}
 	@Test
 	public void buildsWholeSubtree() throws Exception {
-		Assert.assertThat(radioGroupBuilder.shouldSkipChildren(null), equalTo(true));
+		assertThat(radioGroupBuilder.shouldSkipChildren(null), equalTo(true));
 	}
 }

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/JMenubarBuilderTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/JMenubarBuilderTest.java
@@ -1,6 +1,6 @@
 package org.freeplane.core.ui.menubuilders.menu;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/JToolbarBuilderTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/JToolbarBuilderTest.java
@@ -1,6 +1,6 @@
 package org.freeplane.core.ui.menubuilders.menu;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/JToolbarComponentBuilderTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/JToolbarComponentBuilderTest.java
@@ -1,7 +1,7 @@
 package org.freeplane.core.ui.menubuilders.menu;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.awt.Container;

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/MenuAcceleratorChangeListenerTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/MenuAcceleratorChangeListenerTest.java
@@ -1,6 +1,7 @@
 package org.freeplane.core.ui.menubuilders.menu;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.awt.event.KeyEvent;
@@ -12,7 +13,6 @@ import org.freeplane.core.ui.AFreeplaneAction;
 import org.freeplane.core.ui.menubuilders.action.EntriesForAction;
 import org.freeplane.core.ui.menubuilders.generic.Entry;
 import org.freeplane.core.ui.menubuilders.generic.EntryAccessor;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class MenuAcceleratorChangeListenerTest {
@@ -28,6 +28,6 @@ public class MenuAcceleratorChangeListenerTest {
 
 		final KeyStroke keyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_INSERT, 0);
 		menuAcceleratorChangeListener.acceleratorChanged(action, null, keyStroke);
-		Assert.assertThat(menu.getAccelerator(), equalTo(keyStroke));
+		assertThat(menu.getAccelerator(), equalTo(keyStroke));
 	}
 }

--- a/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/ToolbarComponentProviderTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/menubuilders/menu/ToolbarComponentProviderTest.java
@@ -1,6 +1,7 @@
 package org.freeplane.core.ui.menubuilders.menu;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.awt.Component;
 
@@ -8,7 +9,6 @@ import javax.swing.JPanel;
 
 import org.freeplane.core.ui.menubuilders.generic.Entry;
 import org.freeplane.core.ui.menubuilders.generic.EntryAccessor;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ToolbarComponentProviderTest {
@@ -19,6 +19,6 @@ public class ToolbarComponentProviderTest {
 		final EntryAccessor entryAccessor = new EntryAccessor();
 		final Component testComponent = new JPanel();
 		entryAccessor.setComponent(entry, testComponent);
-		Assert.assertThat(toolbarComponentProvider.createComponent(entry), equalTo(testComponent));
+		assertThat(toolbarComponentProvider.createComponent(entry), equalTo(testComponent));
 	}
 }

--- a/freeplane/src/test/java/org/freeplane/core/util/ConstantObjectShould.java
+++ b/freeplane/src/test/java/org/freeplane/core/util/ConstantObjectShould.java
@@ -1,7 +1,7 @@
 package org.freeplane.core.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/freeplane/src/test/java/org/freeplane/core/util/RuleReferenceShould.java
+++ b/freeplane/src/test/java/org/freeplane/core/util/RuleReferenceShould.java
@@ -1,7 +1,7 @@
 package org.freeplane.core.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/freeplane/src/test/java/org/freeplane/features/map/ClonesTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/map/ClonesTest.java
@@ -20,10 +20,10 @@
 package org.freeplane.features.map;
 
 import static org.freeplane.features.map.NodeModel.CloneType.TREE;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 
 import org.hamcrest.collection.IsEmptyIterable;
 import org.junit.Test;

--- a/freeplane/src/test/java/org/freeplane/features/map/NodeRelativePathTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/map/NodeRelativePathTest.java
@@ -20,8 +20,9 @@
 package org.freeplane.features.map;
 
 import static org.freeplane.features.map.NodeModel.CloneType.TREE;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -162,7 +163,7 @@ public class NodeRelativePathTest {
 	public void compareSameNode(){
 		final NodeModel parent = root();
 		final int compared = new NodeRelativePath(parent, parent).compareNodePositions();
-		assertTrue(compared == 0);
+		assertEquals(0, compared);
 	}
 
 	@Test

--- a/freeplane/src/test/java/org/freeplane/features/map/SummaryLevelsShould.java
+++ b/freeplane/src/test/java/org/freeplane/features/map/SummaryLevelsShould.java
@@ -1,7 +1,7 @@
 package org.freeplane.features.map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/freeplane/src/test/java/org/freeplane/features/map/mindmapmode/SummaryGroupEdgeListAdderShould.java
+++ b/freeplane/src/test/java/org/freeplane/features/map/mindmapmode/SummaryGroupEdgeListAdderShould.java
@@ -1,7 +1,7 @@
 package org.freeplane.features.map.mindmapmode;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/freeplane/src/test/java/org/freeplane/features/presentations/mindmapmode/CollectionModelShould.java
+++ b/freeplane/src/test/java/org/freeplane/features/presentations/mindmapmode/CollectionModelShould.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.freeplane.features.presentations.mindmapmode.CollectionChangedEvent.EventType.COLLECTION_SIZE_CHANGED;
 import static org.freeplane.features.presentations.mindmapmode.CollectionChangedEvent.EventType.SELECTION_CHANGED;
 import static org.freeplane.features.presentations.mindmapmode.CollectionChangedEvent.EventType.SELECTION_INDEX_CHANGED;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.refEq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -16,7 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CollectionModelShould {

--- a/freeplane_ant/src/test/java/org/freeplane/ant/FormatTranslationTest.java
+++ b/freeplane_ant/src/test/java/org/freeplane/ant/FormatTranslationTest.java
@@ -15,6 +15,7 @@
  */
 package org.freeplane.ant;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -25,7 +26,6 @@ import java.util.Arrays;
 
 import org.apache.tools.ant.Project;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -170,18 +170,18 @@ public class FormatTranslationTest {
 	@Test
 	public void convertsUnicodeToUpperCase(){
 		final FormatTranslation formatTranslation = new FormatTranslation();
-		Assert.assertThat(formatTranslation.convertUnicodeCharacterRepresentation("u"), CoreMatchers.equalTo("u"));
-		Assert.assertThat(formatTranslation.convertUnicodeCharacterRepresentation("\\Uabcde"), CoreMatchers.equalTo("\\uABCDe"));
-		Assert.assertThat(formatTranslation.convertUnicodeCharacterRepresentation("\\uabcde"), CoreMatchers.equalTo("\\uABCDe"));
-		Assert.assertThat(formatTranslation.convertUnicodeCharacterRepresentation("1\\Uabcde"), CoreMatchers.equalTo("1\\uABCDe"));
+		assertThat(formatTranslation.convertUnicodeCharacterRepresentation("u"), CoreMatchers.equalTo("u"));
+		assertThat(formatTranslation.convertUnicodeCharacterRepresentation("\\Uabcde"), CoreMatchers.equalTo("\\uABCDe"));
+		assertThat(formatTranslation.convertUnicodeCharacterRepresentation("\\uabcde"), CoreMatchers.equalTo("\\uABCDe"));
+		assertThat(formatTranslation.convertUnicodeCharacterRepresentation("1\\Uabcde"), CoreMatchers.equalTo("1\\uABCDe"));
 	}
 
 	@Test
 	public void convertsLatin1toUnicode() {
 		final FormatTranslation formatTranslation = new FormatTranslation();
-		Assert.assertThat(formatTranslation.convertUnicodeCharacterRepresentation("ä"),
+		assertThat(formatTranslation.convertUnicodeCharacterRepresentation("ä"),
 		    CoreMatchers.equalTo("\\u00E4"));
-		Assert.assertThat(formatTranslation.convertUnicodeCharacterRepresentation("ä1"),
+		assertThat(formatTranslation.convertUnicodeCharacterRepresentation("ä1"),
 		    CoreMatchers.equalTo("\\u00E41"));
 	}
 }

--- a/freeplane_api/src/test/java/org/freeplane/api/QuantityTest.java
+++ b/freeplane_api/src/test/java/org/freeplane/api/QuantityTest.java
@@ -1,12 +1,11 @@
 package org.freeplane.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.freeplane.api.LengthUnit.cm;
 import static org.freeplane.api.LengthUnit.pt;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 
@@ -148,16 +147,16 @@ public class QuantityTest {
     
     @Test
     public void rounds4cm_WhenConvertsToString() throws Exception {
-        assertThat(new Quantity<>(4, cm).toString()).isEqualTo("4 cm");
-        assertThat(new Quantity<>(4, cm).in(pt).toString()).isEqualTo("113.38583 pt");
-        assertThat(Quantity.fromString("113.38583 pt", cm).toString()).isEqualTo("113.38583 pt");
-        assertThat(Quantity.fromString("113.38583 pt", cm).in(cm).toString()).isEqualTo("4 cm");
+        assertThat(new Quantity<>(4, cm).toString(), equalTo("4 cm"));
+        assertThat(new Quantity<>(4, cm).in(pt).toString(), equalTo("113.38583 pt"));
+        assertThat(Quantity.fromString("113.38583 pt", cm).toString(), equalTo("113.38583 pt"));
+        assertThat(Quantity.fromString("113.38583 pt", cm).in(cm).toString(), equalTo("4 cm"));
     }
     @Test
     public void rounds40cm_WhenConvertsToString() throws Exception {
-        assertThat(new Quantity<>(40, cm).toString()).isEqualTo("40 cm");
-        assertThat(new Quantity<>(40, cm).in(pt).toString()).isEqualTo("1133.85827 pt");
-        assertThat(Quantity.fromString("1133.85827 pt", cm).toString()).isEqualTo("1133.85827 pt");
-        assertThat(Quantity.fromString("1133.85827 pt", cm).in(cm).toString()).isEqualTo("40 cm");
+        assertThat(new Quantity<>(40, cm).toString(), equalTo("40 cm"));
+        assertThat(new Quantity<>(40, cm).in(pt).toString(), equalTo("1133.85827 pt"));
+        assertThat(Quantity.fromString("1133.85827 pt", cm).toString(), equalTo("1133.85827 pt"));
+        assertThat(Quantity.fromString("1133.85827 pt", cm).in(cm).toString(), equalTo("40 cm"));
     }
 }

--- a/freeplane_framework/src/test/java/org/freeplane/launcher/TestApp.java
+++ b/freeplane_framework/src/test/java/org/freeplane/launcher/TestApp.java
@@ -20,7 +20,7 @@ public class TestApp {
 	private static void createNewMindMap(File freeplaneInstallationDirectory, final File newMapFile) {
 		final Launcher launcher = Launcher.createForInstallation(freeplaneInstallationDirectory).disableSecurityManager();
 		HeadlessMapCreator mapCreator = launcher.launchHeadless();
-		final MindMap map = mapCreator.mapLoader(TestApp.class.getResource("/templateFile.mm")).unsetMapLocation().load();
+		final MindMap map = mapCreator.mapLoader(TestApp.class.getResource("/templateFile.mm")).unsetMapLocation().getMindMap();
 		if(map != null) {
 		    final Node childNode = map.getRoot().createChild();
 		    String value = "hello world";

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/InternationalizedSecurityManager.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/InternationalizedSecurityManager.java
@@ -201,8 +201,7 @@ class InternationalizedSecurityManager extends SecurityManager {
 	}
 
 	private SecurityException getException(final AccessControlException e, final int pPermissionGroup, final int pPermission, final String pFile) {
-		final String message = TextUtils.format("plugins/ScriptEditor.FORBIDDEN_ACTION", new Integer(
-			    pPermissionGroup), new Integer(pPermission), pFile);
+		final String message = TextUtils.format("plugins/ScriptEditor.FORBIDDEN_ACTION", pPermissionGroup, pPermission, pFile);
 		return new SecurityException(message, e);
     }
 
@@ -222,7 +221,7 @@ class InternationalizedSecurityManager extends SecurityManager {
 	@Override
 	public void checkPermission(Permission perm, Object context) {
 		disallowSupressingAccessChecks(perm);
-		super.checkPermission(perm, context);	
+		super.checkPermission(perm, context);
 	}
 	
 	

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/ScriptEditorPanel.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/ScriptEditorPanel.java
@@ -464,7 +464,7 @@ class ScriptEditorPanel extends JDialog {
 		}
 		storeCurrent();
 		mScriptTextField.setText(mScriptModel.getScript(pIndex).getScript());
-		mLastSelected = new Integer(pIndex);
+		mLastSelected = pIndex;
 		if (pIndex >= 0 && mScriptList.getSelectedIndex() != pIndex) {
 			mScriptList.setSelectedIndex(pIndex);
 		}
@@ -472,7 +472,7 @@ class ScriptEditorPanel extends JDialog {
 
 	private void storeCurrent() {
 		if (mLastSelected != null) {
-			final int oldIndex = mLastSelected.intValue();
+			final int oldIndex = mLastSelected;
 			mScriptModel.setScript(oldIndex, mScriptModel.getScript(oldIndex).setScript(mScriptTextField.getText()));
 		}
 	}

--- a/freeplane_plugin_script/src/test/java/org/freeplane/plugin/script/CompiledFilesSpec.java
+++ b/freeplane_plugin_script/src/test/java/org/freeplane/plugin/script/CompiledFilesSpec.java
@@ -84,7 +84,7 @@ public class CompiledFilesSpec {
         PrecompiledClasses uut = PrecompiledClasses.readThrowExceptions(eventReader);
 		
         final PrecompiledClasses expected = new PrecompiledClasses(2, Collections.singleton("file"));
-		assertThat(uut).isEqualToComparingFieldByField(expected);
+		assertThat(uut).usingRecursiveComparison().isEqualTo(expected);
 
 	}
 	
@@ -95,7 +95,6 @@ public class CompiledFilesSpec {
 		PrecompiledClasses uut = compiledFiles;
 		
         final PrecompiledClasses expected = new PrecompiledClasses(2, Collections.singleton(new File("file").getAbsolutePath()));
-		assertThat(uut).isEqualToComparingFieldByField(expected);
-
+		assertThat(uut).usingRecursiveComparison().isEqualTo(expected);
 	}
 }

--- a/freeplane_plugin_svg/src/main/java/org/freeplane/plugin/svg/ExportPdf.java
+++ b/freeplane_plugin_svg/src/main/java/org/freeplane/plugin/svg/ExportPdf.java
@@ -108,8 +108,8 @@ class ExportPdf extends ExportVectorGraphic {
 		 * Frank Spangenberg (f_spangenberg) Summary: Large mind maps
 		 * produce invalid PDF
 		 */
-		pdfTranscoder.addTranscodingHint(SVGAbstractTranscoder.KEY_MAX_HEIGHT, new Float(19200));
-		pdfTranscoder.addTranscodingHint(SVGAbstractTranscoder.KEY_MAX_WIDTH, new Float(19200));
+		pdfTranscoder.addTranscodingHint(SVGAbstractTranscoder.KEY_MAX_HEIGHT, 19200F);
+		pdfTranscoder.addTranscodingHint(SVGAbstractTranscoder.KEY_MAX_WIDTH, 19200F);
 		/* end patch */
 		pdfTranscoder.addTranscodingHint(ImageTranscoder.KEY_PIXEL_UNIT_TO_MILLIMETER, 25.4f/72f/ UITools.FONT_SCALE_FACTOR);
 		if(ResourceController.getResourceController().getBooleanProperty(PDF_CONVERT_TEXT_TO_SHAPES)) {


### PR DESCRIPTION
These are mostly coming from tests where using `org.junit.Assert.assertThat` which is deprecated. Instead use the included `org.hamcrest.MatcherAssert.assertThat`.

Rest of changes include:
- auto-boxing-unboxing of primitives
- use try-with-resources
- use recursiveComparison on `equalsTo()`