### PR TITLE
[fix 232] put filename before folder in Most Recent Maps submenu

### DIFF
--- a/freeplane/src/main/java/org/freeplane/main/application/LastOpenedList.java
+++ b/freeplane/src/main/java/org/freeplane/main/application/LastOpenedList.java
@@ -489,16 +489,25 @@ public class LastOpenedList implements IMapViewChangeListener, IMapChangeListene
 			openMapAction.putValue(Action.NAME, restorable);
 
 		String key = restorable.substring(0, separatorIndex);
-		String fileName = restorable.substring(separatorIndex);
+		String filePath = restorable.substring(separatorIndex);
 		String keyName = TextUtils.getText("open_as" + key, key);
 		openMapAction.putValue(Action.SHORT_DESCRIPTION, keyName);
-		openMapAction.putValue(Action.DEFAULT, fileName);
-		if(fileName.startsWith("::"))
-			fileName = fileName.substring(2);
+		openMapAction.putValue(Action.DEFAULT, filePath);
+		if(filePath.startsWith("::"))
+			filePath = filePath.substring(2);
 		else
-			fileName = fileName.substring(1);
-
-		openMapAction.putValue(Action.NAME, keyName + " " + fileName);
+			filePath = filePath.substring(1);
+		final int fileSeparatorIndex = filePath.lastIndexOf('/');
+		String actionName;
+		if(fileSeparatorIndex == -1) {
+			actionName = keyName + " "+ filePath;
+		}
+		else {
+			String fileName = filePath.substring(fileSeparatorIndex + 1);
+			String folderPath = filePath.substring(0, fileSeparatorIndex);
+			actionName = keyName + " " + fileName + " (" + folderPath + ")";
+		}
+		openMapAction.putValue(Action.NAME, actionName);
 
     }
 


### PR DESCRIPTION
This change aims to address [issues 232](https://github.com/freeplane/freeplane/issues/232) by separating the file from the absolute file paths. 

After fix:
<img width="1099" alt="Screen Shot 2021-11-21 at 9 25 24 PM" src="https://user-images.githubusercontent.com/91864114/142808749-cbbd6bc1-328f-48ed-9951-051ce3cc361c.png">

