### PR TITLE
Add StartupWMClass key to desktop file to avoid a separate running application icon

### DIFF
--- a/debian-meta-data/freeplane.desktop
+++ b/debian-meta-data/freeplane.desktop
@@ -10,3 +10,4 @@ Categories=Office;
 GenericName=Freeplane
 Comment=A free tool to structure and organise your information with mind mapping
 Keywords=Mindmaps; Knowledge management; Organize information; Brainstorming; ...;
+StartupWMClass=org-knopflerfish-framework-BundleThread


### PR DESCRIPTION
Hello,

if you add Freeplane to favourites in Gnome and start Freeplane, there will be a separate icon to indicate the running instance of Freeplane.

This change to the desktop file fixes this to the correct behaviour (a white dot under the Freeplane icon which was added to favourites instead of a separate icon).

Tested and fixed for Gnome Shell 3.38 / Debian 11, but should work for all Linux desktop environments.

Cheers,
Wolfram