### PR TITLE
fix the issue that freeplane.exe cannot launch

### DIFF
--- a/freeplane_framework/launch4j/freeplaneGui.lj4.xml
+++ b/freeplane_framework/launch4j/freeplaneGui.lj4.xml
@@ -15,7 +15,7 @@
   <manifest></manifest>
   <icon>Freeplane_app.ico</icon>
   <jre>
-    <path>%FREEPLANE_JAVA_HOME%;%JAVA_HOME</path>
+    <path>%FREEPLANE_JAVA_HOME%;%JAVA_HOME%</path>
     <bundledJre64Bit>false</bundledJre64Bit>
     <bundledJreAsFallback>false</bundledJreAsFallback>
     <minVersion>1.8.0</minVersion>


### PR DESCRIPTION
Missing `%` after `%JAVA_HOME` causes freeplane cannot launch.