### PR TITLE
Add support for reproducible builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,10 @@ subprojects {
     tasks.withType(JavaCompile) {
       options.encoding = "UTF-8"
     }
+    tasks.withType(AbstractArchiveTask).configureEach {
+      preserveFileTimestamps = false
+      reproducibleFileOrder = true
+    }
     javadoc {
       options.encoding = "UTF-8"
       options.docEncoding = "UTF-8"


### PR DESCRIPTION
Hi,

I'm the package maintainer for `freeplane` in Arch Linux and trying to make this package reproducible [1]. This will make the archives (JAR, ZIP etc) to omit timestamp information and maintain order within the archives between builds.

It also helps on gradle incremental builds to use more efficient the gradle internal cache.

[1]: https://reproducible-builds.org/