### PR TITLE
Fixing all warnings: [cast] redundant cast to X

### DIFF
--- a/freeplane/src/main/java/com/thebuzzmedia/imgscalr/Scalr.java
+++ b/freeplane/src/main/java/com/thebuzzmedia/imgscalr/Scalr.java
@@ -1807,7 +1807,7 @@ public class Scalr {
 
 		// Create our target image we will render the rotated result to.
 		BufferedImage result = createOptimalImage(src, newWidth, newHeight);
-		Graphics2D g2d = (Graphics2D) result.createGraphics();
+		Graphics2D g2d = result.createGraphics();
 
 		/*
 		 * Render the resultant image to our new rotatedImage buffer, applying

--- a/freeplane/src/main/java/org/freeplane/core/io/xml/StdXMLBuilder.java
+++ b/freeplane/src/main/java/org/freeplane/core/io/xml/StdXMLBuilder.java
@@ -150,7 +150,7 @@ class StdXMLBuilder implements IXMLBuilder {
 		final XMLElement elt = prototype.createElement(null, systemID, lineNr);
 		elt.setContent(str.toString());
 		if (!stack.empty()) {
-			final XMLElement top = (XMLElement) stack.peek();
+			final XMLElement top = stack.peek();
 			top.addChild(elt);
 		}
 	}
@@ -189,7 +189,7 @@ class StdXMLBuilder implements IXMLBuilder {
 	 *            parameter is null.
 	 */
 	public void endElement(final String name, final String nsPrefix, final String nsURI) {
-		final XMLElement elt = (XMLElement) stack.pop();
+		final XMLElement elt = stack.pop();
 		if (elt.getChildrenCount() == 1) {
 			final XMLElement child = elt.getChildAtIndex(0);
 			if (child.getName() == null) {
@@ -217,7 +217,7 @@ class StdXMLBuilder implements IXMLBuilder {
 	}
 
 	public XMLElement getParentElement() {
-		return root != null ? (XMLElement) stack.peek() : null;
+		return root != null ? stack.peek() : null;
 	}
 
 	/**
@@ -287,7 +287,7 @@ class StdXMLBuilder implements IXMLBuilder {
 			root = elt;
 		}
 		else {
-			final XMLElement top = (XMLElement) stack.peek();
+			final XMLElement top = stack.peek();
 			top.addChild(elt);
 		}
 		stack.push(elt);

--- a/freeplane/src/main/java/org/freeplane/core/io/xml/TreeXmlReader.java
+++ b/freeplane/src/main/java/org/freeplane/core/io/xml/TreeXmlReader.java
@@ -173,7 +173,7 @@ public class TreeXmlReader implements IXMLBuilder {
 			}
 			final Enumeration<String> attributeNames = lastBuiltElement.enumerateAttributeNames();
 			while (attributeNames.hasMoreElements()) {
-				final String atName = (String) attributeNames.nextElement();
+				final String atName = attributeNames.nextElement();
 				if (addAttribute(atName, lastBuiltElement.getAttribute(atName, null))) {
 					lastBuiltElement.removeAttribute(atName);
 				}
@@ -224,7 +224,7 @@ public class TreeXmlReader implements IXMLBuilder {
 			final int lastChildIndex = top.getChildrenCount() - 1;
 			top.removeChildAtIndex(lastChildIndex);
 		}
-		nodeCreator = (IElementHandler) nodeCreatorStack.removeLast();
+		nodeCreator = nodeCreatorStack.removeLast();
 		elementContentAsString = null;
 	}
 

--- a/freeplane/src/main/java/org/freeplane/core/io/xml/XMLWriter.java
+++ b/freeplane/src/main/java/org/freeplane/core/io/xml/XMLWriter.java
@@ -152,7 +152,7 @@ class XMLWriter {
 			}
 			Enumeration<String> enumAttributeNames = xml.enumerateAttributeNames();
 			while (enumAttributeNames.hasMoreElements()) {
-				final String key = (String) enumAttributeNames.nextElement();
+				final String key = enumAttributeNames.nextElement();
 				final int index = key.indexOf(':');
 				if (index >= 0) {
 					final String namespace = xml.getAttributeNamespace(key);
@@ -168,7 +168,7 @@ class XMLWriter {
 			}
 			enumAttributeNames = xml.enumerateAttributeNames();
 			while (enumAttributeNames.hasMoreElements()) {
-				final String key = (String) enumAttributeNames.nextElement();
+				final String key = enumAttributeNames.nextElement();
 				final String value = xml.getAttribute(key, null);
 				writer.print(" " + key + "=\"");
 				this.writeEncoded(value, true, false);

--- a/freeplane/src/main/java/org/freeplane/core/undo/UndoHandler.java
+++ b/freeplane/src/main/java/org/freeplane/core/undo/UndoHandler.java
@@ -119,7 +119,7 @@ public class UndoHandler implements IUndoHandler {
 		}
 		if ((actorList.size() > 0)
 		        && (actionFrameStarted || currentTime - timeOfLastAdd < UndoHandler.TIME_TO_BEGIN_NEW_ACTION)) {
-			CompoundActor compoundActor = (CompoundActor) actorIterator.previous();
+			CompoundActor compoundActor = actorIterator.previous();
 			compoundActor.add(actor);
 			actorIterator.next();
 		}

--- a/freeplane/src/main/java/org/freeplane/features/attribute/ModelessAttributeController.java
+++ b/freeplane/src/main/java/org/freeplane/features/attribute/ModelessAttributeController.java
@@ -34,7 +34,7 @@ public class ModelessAttributeController implements IExtension {
 
 	public static ModelessAttributeController getController() {
 		Controller controller = Controller.getCurrentController();
-		return (ModelessAttributeController) controller.getExtension(ModelessAttributeController.class);
+		return controller.getExtension(ModelessAttributeController.class);
 	}
 
 	public static void install() {

--- a/freeplane/src/main/java/org/freeplane/features/clipboard/HtmlSelection.java
+++ b/freeplane/src/main/java/org/freeplane/features/clipboard/HtmlSelection.java
@@ -32,7 +32,7 @@ public class HtmlSelection implements Transferable {
 	}
 
 	public DataFlavor[] getTransferDataFlavors() {
-		return (DataFlavor[]) htmlFlavors.toArray(new DataFlavor[htmlFlavors.size()]);
+		return htmlFlavors.toArray(new DataFlavor[htmlFlavors.size()]);
 	}
 
 	public boolean isDataFlavorSupported(DataFlavor flavor) {

--- a/freeplane/src/main/java/org/freeplane/features/cloud/CloudController.java
+++ b/freeplane/src/main/java/org/freeplane/features/cloud/CloudController.java
@@ -67,7 +67,7 @@ public class CloudController implements IExtension {
 	}
 
 	public static CloudController getController(ModeController modeController) {
-		return (CloudController) modeController.getExtension(CloudController.class);
+		return modeController.getExtension(CloudController.class);
 	}
 	public static void install( final CloudController cloudController) {
 		Controller.getCurrentModeController().addExtension(CloudController.class, cloudController);

--- a/freeplane/src/main/java/org/freeplane/features/cloud/CloudModel.java
+++ b/freeplane/src/main/java/org/freeplane/features/cloud/CloudModel.java
@@ -26,11 +26,11 @@ import org.freeplane.features.map.NodeModel;
 
 public class CloudModel implements IExtension {
 	public static CloudModel getModel(final NodeModel node) {
-		return (CloudModel) node.getExtension(CloudModel.class);
+		return node.getExtension(CloudModel.class);
 	}
 
 	public static CloudModel createModel(final NodeModel node) {
-		final CloudModel extension = (CloudModel) node.getExtension(CloudModel.class);
+		final CloudModel extension = node.getExtension(CloudModel.class);
 		if (extension != null) {
 			return extension;
 		}

--- a/freeplane/src/main/java/org/freeplane/features/cloud/mindmapmode/MCloudController.java
+++ b/freeplane/src/main/java/org/freeplane/features/cloud/mindmapmode/MCloudController.java
@@ -45,7 +45,7 @@ public class MCloudController extends CloudController {
 		}
 
 		public void copy(final NodeModel from, final NodeModel to) {
-			final CloudModel fromStyle = (CloudModel) from.getExtension(CloudModel.class);
+			final CloudModel fromStyle = from.getExtension(CloudModel.class);
 			if (fromStyle == null) {
 				return;
 			}
@@ -69,11 +69,11 @@ public class MCloudController extends CloudController {
 			if (!key.equals(LogicalStyleKeys.NODE_STYLE)) {
 				return;
 			}
-			final CloudModel whichStyle = (CloudModel) which.getExtension(CloudModel.class);
+			final CloudModel whichStyle = which.getExtension(CloudModel.class);
 			if (whichStyle == null) {
 				return;
 			}
-			final CloudModel fromStyle = (CloudModel) from.getExtension(CloudModel.class);
+			final CloudModel fromStyle = from.getExtension(CloudModel.class);
 			if (fromStyle == null) {
 				return;
 			}

--- a/freeplane/src/main/java/org/freeplane/features/edge/EdgeController.java
+++ b/freeplane/src/main/java/org/freeplane/features/edge/EdgeController.java
@@ -55,7 +55,7 @@ public class EdgeController implements IExtension {
 	}
 	
 	public static EdgeController getController(ModeController modeController) {
-		return (EdgeController) modeController.getExtension(EdgeController.class);
+		return modeController.getExtension(EdgeController.class);
 	}
 	public static void install( final EdgeController edgeController) {
 		Controller.getCurrentModeController().addExtension(EdgeController.class, edgeController);

--- a/freeplane/src/main/java/org/freeplane/features/edge/EdgeModel.java
+++ b/freeplane/src/main/java/org/freeplane/features/edge/EdgeModel.java
@@ -33,7 +33,7 @@ public class EdgeModel implements IExtension {
 	public static final int STANDARD_WIDTH = 1;
 
 	public static EdgeModel createEdgeModel(final NodeModel node) {
-		EdgeModel edge = (EdgeModel) node.getExtension(EdgeModel.class);
+		EdgeModel edge = node.getExtension(EdgeModel.class);
 		if (edge == null) {
 			edge = new EdgeModel();
 			node.addExtension(edge);
@@ -42,7 +42,7 @@ public class EdgeModel implements IExtension {
 	}
 
 	public static EdgeModel getModel(final NodeModel node) {
-		return (EdgeModel) node.getExtension(EdgeModel.class);
+		return node.getExtension(EdgeModel.class);
 	}
 
 	public static void setModel(final NodeModel node, final EdgeModel edge) {

--- a/freeplane/src/main/java/org/freeplane/features/export/mindmapmode/ExportBranchesToHTML.java
+++ b/freeplane/src/main/java/org/freeplane/features/export/mindmapmode/ExportBranchesToHTML.java
@@ -43,7 +43,7 @@ class ExportBranchesToHTML implements IExportEngine {
 	public void export(List<NodeModel> branches, File file) {
 		try {
 			MapClipboardController.getController().saveHTML(branches, file);
-			((UrlManager) Controller.getCurrentModeController().getExtension(UrlManager.class))
+			Controller.getCurrentModeController().getExtension(UrlManager.class)
 			    .loadHyperlink(new Hyperlink(file.toURI()));
 		}
 		catch (final IOException ex) {

--- a/freeplane/src/main/java/org/freeplane/features/export/mindmapmode/ExportController.java
+++ b/freeplane/src/main/java/org/freeplane/features/export/mindmapmode/ExportController.java
@@ -149,7 +149,7 @@ public class ExportController implements IExtension{
     }
 
 	public static ExportController getController(ModeController modeController) {
-		return (ExportController) modeController.getExtension(ExportController.class);
+		return modeController.getExtension(ExportController.class);
     }
 
 	public boolean checkCurrentMap(MapModel map) {

--- a/freeplane/src/main/java/org/freeplane/features/export/mindmapmode/ExportToHTML.java
+++ b/freeplane/src/main/java/org/freeplane/features/export/mindmapmode/ExportToHTML.java
@@ -53,7 +53,7 @@ class ExportToHTML implements IExportEngine {
 				ExportWithXSLT.copyIconsToDirectory(map, new File(file.getAbsoluteFile().getParentFile(), "icons")
 				    .getAbsolutePath());
 			}
-			((UrlManager) Controller.getCurrentModeController().getExtension(UrlManager.class))
+			Controller.getCurrentModeController().getExtension(UrlManager.class)
 			    .loadHyperlink(new Hyperlink(file.toURI()));
 		}
 		catch (final IOException ex) {

--- a/freeplane/src/main/java/org/freeplane/features/filter/PseudoDamerauLevenshtein.java
+++ b/freeplane/src/main/java/org/freeplane/features/filter/PseudoDamerauLevenshtein.java
@@ -216,13 +216,13 @@ public class PseudoDamerauLevenshtein implements EditDistanceStringMatchingStrat
 		matrix = new int[searchTerm.length()+1][searchText.length()+1]; // [row][col]
 		
 		 // first column: start-gap penalties for searchTerm
-		for (int i = 0; i <= (int)searchTerm.length(); i++)
+		for (int i = 0; i <= searchTerm.length(); i++)
 			matrix[i][0] = i*costIndel;
 		
 		// first row: start-gap penalties for searchText
 		if (type == Type.Global)
 		{
-			for (int j = 1; j <= (int)searchText.length(); j++)
+			for (int j = 1; j <= searchText.length(); j++)
 				matrix[0][j] = j*costIndel;
 		}
 		else if (type == Type.SemiGlobal)

--- a/freeplane/src/main/java/org/freeplane/features/format/FormatController.java
+++ b/freeplane/src/main/java/org/freeplane/features/format/FormatController.java
@@ -125,7 +125,7 @@ public class FormatController implements IExtension, IFreeplanePropertyListener 
 	}
 
 	public static FormatController getController(Controller controller) {
-		return (FormatController) controller.getExtension(FormatController.class);
+		return controller.getExtension(FormatController.class);
 	}
 	
 	public static void install(final FormatController formatController) {
@@ -466,8 +466,8 @@ public class FormatController implements IExtension, IFreeplanePropertyListener 
 	public DecimalFormat getDecimalFormat(final String pattern) {
 		DecimalFormat format = numberFormatCache.get(pattern);
 		if (format == null) {
-			format = (DecimalFormat) ((pattern == null) ? getDefaultNumberFormat()
-			        : new DecimalFormat(pattern, new DecimalFormatSymbols(FormatUtils.getFormatLocaleFromResources())));
+			format = (pattern == null) ? getDefaultNumberFormat()
+			        : new DecimalFormat(pattern, new DecimalFormatSymbols(FormatUtils.getFormatLocaleFromResources()));
 			numberFormatCache.put(pattern, format);
 		}
 		return format;

--- a/freeplane/src/main/java/org/freeplane/features/format/ScannerController.java
+++ b/freeplane/src/main/java/org/freeplane/features/format/ScannerController.java
@@ -84,7 +84,7 @@ public class ScannerController implements IExtension, IFreeplanePropertyListener
 	}
 
 	public static ScannerController getController(Controller controller) {
-		return (ScannerController) controller.getExtension(ScannerController.class);
+		return controller.getExtension(ScannerController.class);
 	}
 	
 	public static void install(final ScannerController scannerController) {

--- a/freeplane/src/main/java/org/freeplane/features/icon/IconController.java
+++ b/freeplane/src/main/java/org/freeplane/features/icon/IconController.java
@@ -57,7 +57,7 @@ public class IconController implements IExtension {
 		return getController(modeController);
 	}
 	public static IconController getController(ModeController modeController) {
-		return (IconController) modeController.getExtension(IconController.class);
+		return modeController.getExtension(IconController.class);
     }
 
 	public static void installConditionControllers() {

--- a/freeplane/src/main/java/org/freeplane/features/link/MapLinks.java
+++ b/freeplane/src/main/java/org/freeplane/features/link/MapLinks.java
@@ -81,12 +81,12 @@ public class MapLinks implements IExtension {
 	}
 
 	public static MapLinks getLinks(final MapModel map) {
-		return (MapLinks) map.getExtension(MapLinks.class);
+		return map.getExtension(MapLinks.class);
 	}
 
 
 	public static boolean hasLinks(final MapModel map) {
-		final MapLinks mapLinks = (MapLinks) map.getExtension(MapLinks.class);
+		final MapLinks mapLinks = map.getExtension(MapLinks.class);
 		return mapLinks != null &&mapLinks.getSize() > 0;
 	}
 

--- a/freeplane/src/main/java/org/freeplane/features/map/MapNavigationUtils.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/MapNavigationUtils.java
@@ -7,7 +7,7 @@ public class MapNavigationUtils {
 
     public static NodeModel findNext(final Direction direction, NodeModel current, final NodeModel end) {
     	if (current.getChildCount() != 0) {
-    		final NodeModel next = (NodeModel) current.getChildAt(0);
+    		final NodeModel next = current.getChildAt(0);
     		if (atEnd(next, end)) {
     			return null;
     		}
@@ -24,7 +24,7 @@ public class MapNavigationUtils {
     			Controller.getCurrentModeController().getMapController().fold(current);
     		}
     		if (index < childCount) {
-    			final NodeModel next = (NodeModel) parentNode.getChildAt(index);
+    			final NodeModel next = parentNode.getChildAt(index);
     			if (atEnd(next, end)) {
     				return null;
     			}
@@ -60,7 +60,7 @@ public class MapNavigationUtils {
     			}
     			return parentNode;
     		}
-    		current = (NodeModel) parentNode.getChildAt(index);
+    		current = parentNode.getChildAt(index);
     		if (atEnd(current, end)) {
     			return null;
     		}
@@ -73,7 +73,7 @@ public class MapNavigationUtils {
     			}
     			return current;
     		}
-    		current = (NodeModel) current.getChildAt(current.getChildCount() - 1);
+    		current = current.getChildAt(current.getChildCount() - 1);
     	}
     }
 }

--- a/freeplane/src/main/java/org/freeplane/features/map/NodeModel.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/NodeModel.java
@@ -441,7 +441,7 @@ public class NodeModel{
 				preferredChild = (getChildrenInternal().get(index + 1));
 			}
 			else {
-				preferredChild = (index > 0) ? (NodeModel) (getChildrenInternal().get(index - 1)) : null;
+				preferredChild = (index > 0) ? (getChildrenInternal().get(index - 1)) : null;
 			}
 		}
 		child.setParent(null);

--- a/freeplane/src/main/java/org/freeplane/features/map/SummaryNode.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/SummaryNode.java
@@ -90,7 +90,7 @@ public class SummaryNode extends PersistentNodeHook implements IExtension{
 		final boolean isleft = node.isLeft();
 		int level = 1;
 		for(int i =  index - 1; i > 0; i--){
-			final NodeModel child = (NodeModel) parentNode.getChildAt(i);
+			final NodeModel child = parentNode.getChildAt(i);
 			if(isleft == child.isLeft()){
 				if( isSummaryNode(child))
 					level++;

--- a/freeplane/src/main/java/org/freeplane/features/map/clipboard/CopyIDAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/clipboard/CopyIDAction.java
@@ -32,7 +32,7 @@ public class CopyIDAction extends AFreeplaneAction {
 			sb.append(node.createID());
 		}
 		final String idString = sb.toString();
-		final MapClipboardController clipboardController = (MapClipboardController) Controller.getCurrentModeController().getExtension(
+		final MapClipboardController clipboardController = Controller.getCurrentModeController().getExtension(
 		    MapClipboardController.class);
 		clipboardController.setClipboardContents(new StringSelection(idString));
 		controller.getViewController().out(idString);

--- a/freeplane/src/main/java/org/freeplane/features/map/clipboard/CopySingleAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/clipboard/CopySingleAction.java
@@ -42,10 +42,9 @@ class CopySingleAction extends AFreeplaneAction {
 		final Controller controller = Controller.getCurrentController();
 		final Collection<NodeModel> selection = controller.getSelection().getSortedSelection(false);
 		final ModeController modeController = Controller.getCurrentModeController();
-		final Transferable copy = ((MapClipboardController) modeController.getExtension(MapClipboardController.class))
-		    .copySingle(selection);
+		final Transferable copy = modeController.getExtension(MapClipboardController.class).copySingle(selection);
 		if (copy != null) {
-			((MapClipboardController) modeController.getExtension(MapClipboardController.class)).setClipboardContents(copy);
+			modeController.getExtension(MapClipboardController.class).setClipboardContents(copy);
 		}
 	}
 }

--- a/freeplane/src/main/java/org/freeplane/features/map/mindmapmode/ChangeNodeLevelController.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/mindmapmode/ChangeNodeLevelController.java
@@ -127,7 +127,7 @@ public class ChangeNodeLevelController {
 		final int ownPosition = selectedParent.getIndex(selectedNode);
 		NodeModel directSibling = null;
 		for (int i = ownPosition - 1; i >= 0; --i) {
-			final NodeModel targetCandidate = (NodeModel) selectedParent.getChildAt(i);
+			final NodeModel targetCandidate = selectedParent.getChildAt(i);
 			if (canMoveTo(selectedNode, selectedNodes, targetCandidate)) {
 				directSibling = targetCandidate;
 				break;
@@ -135,7 +135,7 @@ public class ChangeNodeLevelController {
 		}
 		if (directSibling == null) {
 			for (int i = ownPosition + 1; i < selectedParent.getChildCount(); ++i) {
-				final NodeModel targetCandidate = (NodeModel) selectedParent.getChildAt(i);
+				final NodeModel targetCandidate = selectedParent.getChildAt(i);
 				if (canMoveTo(selectedNode, selectedNodes, targetCandidate)) {
 					directSibling = targetCandidate;
 					break;
@@ -144,7 +144,7 @@ public class ChangeNodeLevelController {
 		}
 		if (directSibling != null) {
 			for (final NodeModel node : selectedNodes) {
-				((FreeNode)Controller.getCurrentModeController().getExtension(FreeNode.class)).undoableDeactivateHook(node);
+				(Controller.getCurrentModeController().getExtension(FreeNode.class)).undoableDeactivateHook(node);
 			}
 			mapController.moveNodes(selectedNodes, directSibling, directSibling.getChildCount());
 			Controller.getCurrentModeController().getMapController().selectMultipleNodes(selectedNode, selectedNodes);
@@ -188,7 +188,7 @@ public class ChangeNodeLevelController {
         MapViewLayout layoutType = mapStyleModel.getMapViewLayout();
 		List<List<NodeModel>> movedChildren = layoutType == MapViewLayout.OUTLINE ? findMovedChildren(selectedNode.getParentNode(), selectedNodes) : Collections.emptyList();
 		for (final NodeModel node : selectedNodes)
-			((FreeNode)Controller.getCurrentModeController().getExtension(FreeNode.class)).undoableDeactivateHook(node);
+			(Controller.getCurrentModeController().getExtension(FreeNode.class)).undoableDeactivateHook(node);
 		mapController.moveNodes(selectedNodes, selectedParent, position, leftSide, changeSide);
 		if(layoutType == MapViewLayout.OUTLINE) {
 		    for(int i = 0; i < selectedNodes.size(); i++) {

--- a/freeplane/src/main/java/org/freeplane/features/map/mindmapmode/NewSummaryAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/mindmapmode/NewSummaryAction.java
@@ -104,7 +104,7 @@ class NewSummaryAction extends AFreeplaneAction {
 			return false;
 		int level = summaryLevel;
 		for(int i = start+1; i < end; i++){
-			NodeModel node = (NodeModel) parentNode.getChildAt(i);
+			NodeModel node = parentNode.getChildAt(i);
 			if(isLeft != node.isLeft())
 				continue;
 			if(SummaryNode.isSummaryNode(node))

--- a/freeplane/src/main/java/org/freeplane/features/nodelocation/LocationModel.java
+++ b/freeplane/src/main/java/org/freeplane/features/nodelocation/LocationModel.java
@@ -66,7 +66,7 @@ public class LocationModel implements IExtension {
 	}
 
 	public static LocationModel createLocationModel(final NodeModel node) {
-		LocationModel location = (LocationModel) node.getExtension(LocationModel.class);
+		LocationModel location = node.getExtension(LocationModel.class);
 		if (location == null) {
 			location = new LocationModel();
 			node.addExtension(location);
@@ -75,7 +75,7 @@ public class LocationModel implements IExtension {
 	}
 
 	public static LocationModel getModel(final NodeModel node) {
-		final LocationModel location = (LocationModel) node.getExtension(LocationModel.class);
+		final LocationModel location = node.getExtension(LocationModel.class);
 		return location != null ? location : LocationModel.NULL_LOCATION;
 	}
 

--- a/freeplane/src/main/java/org/freeplane/features/nodestyle/NodeStyleController.java
+++ b/freeplane/src/main/java/org/freeplane/features/nodestyle/NodeStyleController.java
@@ -60,7 +60,7 @@ public class NodeStyleController implements IExtension {
 	}
 
 	public static NodeStyleController getController(ModeController modeController) {
-		return (NodeStyleController) modeController.getExtension(NodeStyleController.class);
+		return modeController.getExtension(NodeStyleController.class);
 	}
 	public static void install( final NodeStyleController styleController) {
 		final ModeController modeController = Controller.getCurrentModeController();

--- a/freeplane/src/main/java/org/freeplane/features/note/NoteController.java
+++ b/freeplane/src/main/java/org/freeplane/features/note/NoteController.java
@@ -148,7 +148,7 @@ public class NoteController implements IExtension {
 				}
 				String text;
 				try {
-					final Object transformed = TextController.getController().getTransformedObjectNoFormattingNoThrow((NodeModel) node, NoteModel.getNote(node), data);
+					final Object transformed = TextController.getController().getTransformedObjectNoFormattingNoThrow(node, NoteModel.getNote(node), data);
 					text = HtmlUtils.objectToHtml(transformed);
 				}
 				catch (Exception e) {

--- a/freeplane/src/main/java/org/freeplane/features/note/NoteModel.java
+++ b/freeplane/src/main/java/org/freeplane/features/note/NoteModel.java
@@ -39,7 +39,7 @@ public class NoteModel extends RichTextModel implements IExtension {
 	}
 
 	public static NoteModel getNote(final NodeModel node) {
-		final NoteModel extension = (NoteModel) node.getExtension(NoteModel.class);
+		final NoteModel extension = node.getExtension(NoteModel.class);
 		return extension;
 	}
 

--- a/freeplane/src/main/java/org/freeplane/features/note/mindmapmode/NoteDialogStarter.java
+++ b/freeplane/src/main/java/org/freeplane/features/note/mindmapmode/NoteDialogStarter.java
@@ -66,7 +66,7 @@ class NoteDialogStarter{
 
 	private void setHtmlText(final NodeModel node, final String newText) {
 		final String body = HTML_HEAD.matcher(newText).replaceFirst("");
-		final MNoteController noteController = (MNoteController) MNoteController.getController();
+		final MNoteController noteController = MNoteController.getController();
 		final String trimmed = body.replaceFirst("\\s+$", "");
 		if(HtmlUtils.isEmpty(trimmed))
 			noteController.setNoteText(node, null);

--- a/freeplane/src/main/java/org/freeplane/features/presentations/mindmapmode/PresentationAutomation.java
+++ b/freeplane/src/main/java/org/freeplane/features/presentations/mindmapmode/PresentationAutomation.java
@@ -49,7 +49,7 @@ class PresentationAutomation implements PresentationStateChangeListener{
 	}
 
 	private JComponent getMapViewComponent() {
-		final JComponent mapViewComponent = (JComponent) Controller.getCurrentController().getMapViewManager().getMapViewComponent();
+		final JComponent mapViewComponent = Controller.getCurrentController().getMapViewManager().getMapViewComponent();
 		return mapViewComponent;
 	}
 

--- a/freeplane/src/main/java/org/freeplane/features/presentations/mindmapmode/PresentationPngExporter.java
+++ b/freeplane/src/main/java/org/freeplane/features/presentations/mindmapmode/PresentationPngExporter.java
@@ -132,7 +132,7 @@ class PresentationPngExporter {
 		this.zoom = Controller.getCurrentController().getMapViewManager().getZoom();
 		final List<NodeModel> selection = Controller.getCurrentController().getSelection().getOrderedSelection();
 		this.selection = selection.toArray(new NodeModel[selection.size()]);
-		mapViewComponent = (JComponent) Controller.getCurrentController().getMapViewManager().getMapViewComponent();
+		mapViewComponent = Controller.getCurrentController().getMapViewManager().getMapViewComponent();
 	}
 
 	private void exportAllPresentations() {

--- a/freeplane/src/main/java/org/freeplane/features/spellchecker/mindmapmode/SpellCheckerController.java
+++ b/freeplane/src/main/java/org/freeplane/features/spellchecker/mindmapmode/SpellCheckerController.java
@@ -50,7 +50,7 @@ public class SpellCheckerController implements IExtension {
 
 	public static SpellCheckerController getController() {
 		final ModeController modeController = Controller.getCurrentModeController();
-		return (SpellCheckerController) modeController.getExtension(SpellCheckerController.class);
+		return modeController.getExtension(SpellCheckerController.class);
 	}
 
 	public static void install(final ModeController modeController) {

--- a/freeplane/src/main/java/org/freeplane/features/styles/LogicalStyleModel.java
+++ b/freeplane/src/main/java/org/freeplane/features/styles/LogicalStyleModel.java
@@ -38,7 +38,7 @@ public class LogicalStyleModel implements IExtension {
 	}
 
 	static public LogicalStyleModel getExtension(final NodeModel node) {
-		return (LogicalStyleModel) node.getExtension(LogicalStyleModel.class);
+		return node.getExtension(LogicalStyleModel.class);
 	}
 
 	static public IStyle getStyle(final NodeModel node) {
@@ -51,7 +51,7 @@ public class LogicalStyleModel implements IExtension {
 	}
 
 	static public LogicalStyleModel createExtension(final NodeModel node) {
-		LogicalStyleModel extension = (LogicalStyleModel) node.getExtension(LogicalStyleModel.class);
+		LogicalStyleModel extension = node.getExtension(LogicalStyleModel.class);
 		if (extension == null) {
 			extension = new LogicalStyleModel();
 			node.addExtension(extension);

--- a/freeplane/src/main/java/org/freeplane/features/styles/SetBooleanMapViewPropertyAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/styles/SetBooleanMapViewPropertyAction.java
@@ -59,7 +59,7 @@ public class SetBooleanMapViewPropertyAction extends AFreeplaneAction{
     }
 
 	private JComponent getMapViewComponent() {
-		final JComponent mapViewComponent = (JComponent) Controller.getCurrentController().getMapViewManager().getMapViewComponent();
+		final JComponent mapViewComponent = Controller.getCurrentController().getMapViewManager().getMapViewComponent();
 		return mapViewComponent;
 	}
 

--- a/freeplane/src/main/java/org/freeplane/features/styles/mindmapmode/ManageNodeConditionalStylesAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/styles/mindmapmode/ManageNodeConditionalStylesAction.java
@@ -85,7 +85,7 @@ public class ManageNodeConditionalStylesAction extends AManageConditionalStylesA
 	public ConditionalStyleModel getConditionalStyleModel() {
 		final Controller controller = Controller.getCurrentController();
 		final NodeModel node = controller.getSelection().getSelected();
-		ConditionalStyleModel conditionalStyleModel = (ConditionalStyleModel) node.getExtension(ConditionalStyleModel.class);
+		ConditionalStyleModel conditionalStyleModel = node.getExtension(ConditionalStyleModel.class);
 		if(conditionalStyleModel == null){
 			conditionalStyleModel = new ConditionalStyleModel();
 			node.addExtension(conditionalStyleModel);

--- a/freeplane/src/main/java/org/freeplane/features/styles/mindmapmode/MapBackgroundColorAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/styles/mindmapmode/MapBackgroundColorAction.java
@@ -50,7 +50,7 @@ class MapBackgroundColorAction extends AFreeplaneAction {
 
 	public void actionPerformed(final ActionEvent e) {
 		final Controller controller = Controller.getCurrentController();
-		MapStyle mapStyle = (MapStyle) controller.getModeController().getExtension(MapStyle.class);
+		MapStyle mapStyle = controller.getModeController().getExtension(MapStyle.class);
 		final MapStyleModel model = (MapStyleModel) mapStyle.getMapHook(controller.getMap());
 		final Color oldBackgroundColor;
 		final String colorPropertyString = ResourceController.getResourceController().getProperty(

--- a/freeplane/src/main/java/org/freeplane/features/styles/mindmapmode/styleeditorpanel/StyleControlGroup.java
+++ b/freeplane/src/main/java/org/freeplane/features/styles/mindmapmode/styleeditorpanel/StyleControlGroup.java
@@ -147,7 +147,7 @@ class StyleControlGroup implements ControlGroup{
 			}
 			if(mAutomaticEdgeColorComboBox != null){
 				final ModeController modeController = Controller.getCurrentModeController();
-				AutomaticEdgeColorHook al = (AutomaticEdgeColorHook) modeController.getExtension(AutomaticEdgeColorHook.class);
+				AutomaticEdgeColorHook al = modeController.getExtension(AutomaticEdgeColorHook.class);
 				final AutomaticEdgeColor extension = (AutomaticEdgeColor) al.getExtension(node);
 				if(extension == null) {
 					mAutomaticEdgeColorComboBox.setSelectedItem(AUTOMATIC_LAYOUT_DISABLED);

--- a/freeplane/src/main/java/org/freeplane/features/text/DetailModel.java
+++ b/freeplane/src/main/java/org/freeplane/features/text/DetailModel.java
@@ -37,7 +37,7 @@ public class DetailModel extends RichTextModel implements IExtension {
     }
 
     public static DetailModel getDetail(final NodeModel node) {
-        final DetailModel extension = (DetailModel) node.getExtension(DetailModel.class);
+        final DetailModel extension = node.getExtension(DetailModel.class);
         return extension;
     }
 

--- a/freeplane/src/main/java/org/freeplane/features/text/ShortenedTextModel.java
+++ b/freeplane/src/main/java/org/freeplane/features/text/ShortenedTextModel.java
@@ -41,7 +41,7 @@ public class ShortenedTextModel implements IExtension {
 	}
 
 	public static ShortenedTextModel getShortenedTextModel(final NodeModel node) {
-		final ShortenedTextModel extension = (ShortenedTextModel) node.getExtension(ShortenedTextModel.class);
+		final ShortenedTextModel extension = node.getExtension(ShortenedTextModel.class);
 		return extension;
 	}
 	

--- a/freeplane/src/main/java/org/freeplane/features/text/TextController.java
+++ b/freeplane/src/main/java/org/freeplane/features/text/TextController.java
@@ -374,7 +374,7 @@ public class TextController implements IExtension {
 				String data = details.getText();
 				String text;
 				try {
-					final Object transformed = TextController.getController().getTransformedObjectNoFormattingNoThrow((NodeModel) node, details, data);
+					final Object transformed = TextController.getController().getTransformedObjectNoFormattingNoThrow(node, details, data);
 					text = HtmlUtils.objectToHtml(transformed);
 				}
 				catch (Exception e) {
@@ -414,7 +414,7 @@ public class TextController implements IExtension {
 				final Object data = node.getUserObject();
 				String text;
 				try {
-					final Object transformed = TextController.getController().getTransformedObjectNoFormattingNoThrow((NodeModel) node, node, data);
+					final Object transformed = TextController.getController().getTransformedObjectNoFormattingNoThrow(node, node, data);
 					text = HtmlUtils.objectToHtml(transformed);
 					if (text.equals(getShortText(text)))
 						return null;

--- a/freeplane/src/main/java/org/freeplane/features/url/mindmapmode/OpenUserDirAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/url/mindmapmode/OpenUserDirAction.java
@@ -44,7 +44,7 @@ class OpenUserDirAction extends AFreeplaneAction {
 
 	private UrlManager getURLManager() {
 		ModeController modeController = Controller.getCurrentModeController();
-		return (UrlManager) modeController.getExtension(UrlManager.class);
+		return modeController.getExtension(UrlManager.class);
 	}
 
 	@Override

--- a/freeplane/src/main/java/org/freeplane/main/addons/AddOnProperties.java
+++ b/freeplane/src/main/java/org/freeplane/main/addons/AddOnProperties.java
@@ -289,7 +289,7 @@ public class AddOnProperties {
             else if (updateUrl instanceof URI)
                 return ((URI) updateUrl).toURL();
 			else
-				return new URL((String) updateUrl.toString());
+				return new URL(updateUrl.toString());
 		}
 		catch (MalformedURLException e) {
 			throw new IllegalArgumentException(e);

--- a/freeplane/src/main/java/org/freeplane/main/mindmapmode/stylemode/SModeController.java
+++ b/freeplane/src/main/java/org/freeplane/main/mindmapmode/stylemode/SModeController.java
@@ -99,7 +99,7 @@ public class SModeController extends MModeController {
 	void tryToCloseDialog() {
 	    final IMapViewManager mapViewManager = getController().getMapViewManager();
 	    final MapModel map = mapViewManager.getModel();
-	    final IUndoHandler undoHandler = (IUndoHandler) map.getExtension(IUndoHandler.class);
+	    final IUndoHandler undoHandler = map.getExtension(IUndoHandler.class);
 	    final Window dialog = ((DialogController) getController().getViewController()).getDialog();
 	    if (! undoHandler.canUndo()){
 	    	dialog.setVisible(false);

--- a/freeplane/src/main/java/org/freeplane/n3/nanoxml/NonValidator.java
+++ b/freeplane/src/main/java/org/freeplane/n3/nanoxml/NonValidator.java
@@ -89,7 +89,7 @@ public class NonValidator implements IXMLValidator {
 	 */
 	public void elementAttributesProcessed(final String name, final Properties extraAttributes, final String systemId,
 	                                       final int lineNr) {
-		final Properties props = (Properties) currentElements.pop();
+		final Properties props = currentElements.pop();
 		final Enumeration<Object> enumeration = props.keys();
 		while (enumeration.hasMoreElements()) {
 			final String key = (String) enumeration.nextElement();
@@ -121,7 +121,7 @@ public class NonValidator implements IXMLValidator {
 	 *            the line number in the XML data of the element.
 	 */
 	public void elementStarted(final String name, final String systemId, final int lineNr) {
-		Properties attribs = (Properties) attributeDefaultValues.get(name);
+		Properties attribs = attributeDefaultValues.get(name);
 		if (attribs == null) {
 			attribs = new Properties();
 		}

--- a/freeplane/src/main/java/org/freeplane/n3/nanoxml/StdXMLBuilder.java
+++ b/freeplane/src/main/java/org/freeplane/n3/nanoxml/StdXMLBuilder.java
@@ -88,7 +88,7 @@ class StdXMLBuilder implements IXMLBuilder {
 		if (nsPrefix != null) {
 			fullName = nsPrefix + ':' + key;
 		}
-		final XMLElement top = (XMLElement) stack.peek();
+		final XMLElement top = stack.peek();
 		if (top.hasAttribute(fullName)) {
 			throw new XMLParseException(top.getSystemID(), top.getLineNr(), "Duplicate attribute: " + key);
 		}
@@ -146,7 +146,7 @@ class StdXMLBuilder implements IXMLBuilder {
 		final XMLElement elt = prototype.createElement(null, systemID, lineNr);
 		elt.setContent(str.toString());
 		if (!stack.empty()) {
-			final XMLElement top = (XMLElement) stack.peek();
+			final XMLElement top = stack.peek();
 			top.addChild(elt);
 		}
 	}
@@ -185,7 +185,7 @@ class StdXMLBuilder implements IXMLBuilder {
 	 *            parameter is null.
 	 */
 	public void endElement(final String name, final String nsPrefix, final String nsURI) {
-		final XMLElement elt = (XMLElement) stack.pop();
+		final XMLElement elt = stack.pop();
 		if (elt.getChildrenCount() == 1) {
 			final XMLElement child = elt.getChildAtIndex(0);
 			if (child.getName() == null) {
@@ -274,7 +274,7 @@ class StdXMLBuilder implements IXMLBuilder {
 			root = elt;
 		}
 		else {
-			final XMLElement top = (XMLElement) stack.peek();
+			final XMLElement top = stack.peek();
 			top.addChild(elt);
 		}
 		stack.push(elt);

--- a/freeplane/src/main/java/org/freeplane/n3/nanoxml/StdXMLReader.java
+++ b/freeplane/src/main/java/org/freeplane/n3/nanoxml/StdXMLReader.java
@@ -65,7 +65,7 @@ public class StdXMLReader implements IXMLReader {
 		final StdXMLReader r = new StdXMLReader(new FileInputStream(filename));
 		r.setSystemID(filename);
 		for (int i = 0; i < r.readers.size(); i++) {
-			final StackedReader sr = (StackedReader) r.readers.elementAt(i);
+			final StackedReader sr = r.readers.elementAt(i);
 			sr.systemId = r.currentReader.systemId;
 		}
 		return r;
@@ -186,7 +186,7 @@ public class StdXMLReader implements IXMLReader {
 				return true;
 			}
 			currentReader.pbReader.close();
-			currentReader = (StackedReader) readers.pop();
+			currentReader = readers.pop();
 			ch = readImpl();
 		}
 		unread(ch);
@@ -277,7 +277,7 @@ public class StdXMLReader implements IXMLReader {
 	 */
 	public int getLineNr() {
 		if (currentReader.lineReader == null) {
-			final StackedReader sr = (StackedReader) readers.peek();
+			final StackedReader sr = readers.peek();
 			if (sr.lineReader == null) {
 				return 0;
 			}
@@ -365,7 +365,7 @@ public class StdXMLReader implements IXMLReader {
 				throw new IOException("Unexpected EOF at line " + getLineNr());
 			}
 			currentReader.pbReader.close();
-			currentReader = (StackedReader) readers.pop();
+			currentReader = readers.pop();
 			ch = readImpl();
 		}
 		return (char) ch;

--- a/freeplane/src/main/java/org/freeplane/n3/nanoxml/XMLElement.java
+++ b/freeplane/src/main/java/org/freeplane/n3/nanoxml/XMLElement.java
@@ -580,7 +580,7 @@ public class XMLElement implements Serializable {
 	 *             if the index is out of bounds.
 	 */
 	public XMLElement getChildAtIndex(final int index) throws ArrayIndexOutOfBoundsException {
-		return (XMLElement) children.elementAt(index);
+		return children.elementAt(index);
 	}
 
 	/**
@@ -634,7 +634,7 @@ public class XMLElement implements Serializable {
 		final Vector<XMLElement> result = new Vector<XMLElement>(children.size());
 		final Enumeration<XMLElement> enumeration = children.elements();
 		while (enumeration.hasMoreElements()) {
-			final XMLElement child = (XMLElement) enumeration.nextElement();
+			final XMLElement child = enumeration.nextElement();
 			String str = child.getName();
 			boolean found = (str != null) && (str.equals(name));
 			str = child.getNamespace();
@@ -809,7 +809,7 @@ public class XMLElement implements Serializable {
 			throw new IllegalArgumentException("child must not be null");
 		}
 		if ((child.getName() == null) && (!children.isEmpty())) {
-			final XMLElement lastChild = (XMLElement) children.lastElement();
+			final XMLElement lastChild = children.lastElement();
 			if (lastChild.getName() == null) {
 				lastChild.setContent(lastChild.getContent() + child.getContent());
 				return;

--- a/freeplane/src/main/java/org/freeplane/view/swing/features/filepreview/ExternalResource.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/features/filepreview/ExternalResource.java
@@ -41,7 +41,7 @@ public class ExternalResource implements IExtension {
 
 	public URI getAbsoluteUri(final MapModel map) {
 		try {
-			final UrlManager urlManager = (UrlManager) Controller.getCurrentModeController().getExtension(UrlManager.class);
+			final UrlManager urlManager = Controller.getCurrentModeController().getExtension(UrlManager.class);
 			final URI absoluteUri = urlManager.getAbsoluteUri(map, uri);
 			return absoluteUri;
 		}

--- a/freeplane/src/main/java/org/freeplane/view/swing/features/filepreview/RemoveExternalImageAction.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/features/filepreview/RemoveExternalImageAction.java
@@ -45,8 +45,8 @@ public class RemoveExternalImageAction extends AMultipleNodeAction {
 	@Override
 	public void actionPerformed(final ActionEvent arg0, final NodeModel node) {
 		final ProgressUtilities progUtil = new ProgressUtilities();
-		final ViewerController vc = ((ViewerController) Controller.getCurrentController().getModeController()
-		    .getExtension(ViewerController.class));
+		final ViewerController vc = Controller.getCurrentController().getModeController()
+		    .getExtension(ViewerController.class);
 		if (progUtil.hasExternalResource(node) && !progUtil.hasExtendedProgressIcon(node)) {
 			vc.undoableDeactivateHook(node);
 		}

--- a/freeplane/src/main/java/org/freeplane/view/swing/features/nodehistory/NodeHistory.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/features/nodehistory/NodeHistory.java
@@ -41,7 +41,7 @@ public class NodeHistory implements IExtension {
 
 	static public void install(final ModeController modeController) {
 		final Controller controller = modeController.getController();
-		final NodeHistory history = (NodeHistory) controller.getExtension(NodeHistory.class);
+		final NodeHistory history = controller.getExtension(NodeHistory.class);
 		modeController.getMapController().addNodeSelectionListener(history.getMapSelectionListener());
 		LinkController.getController(modeController).addNodeSelectionListener(history.getLinkSelectionListener());
 		history.backAction = new BackAction(controller, history);

--- a/freeplane/src/main/java/org/freeplane/view/swing/features/progress/mindmapmode/ExtendedProgress10Action.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/features/progress/mindmapmode/ExtendedProgress10Action.java
@@ -29,8 +29,8 @@ class ExtendedProgress10Action extends AMultipleNodeAction {
 	 */
 	@Override
 	protected void actionPerformed(final ActionEvent e, final NodeModel node) {
-		final ViewerController vc = ((ViewerController) Controller.getCurrentController().getModeController()
-		    .getExtension(ViewerController.class));
+		final ViewerController vc = Controller.getCurrentController().getModeController()
+		    .getExtension(ViewerController.class);
 		try {
 	        URI uri = new URI(ResourceController.FREEPLANE_RESOURCE_URL_PROTOCOL, null, "/images/svg/Progress_tenth_00.svg", null);
 			vc.paste(uri, node);

--- a/freeplane/src/main/java/org/freeplane/view/swing/features/progress/mindmapmode/ExtendedProgress25Action.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/features/progress/mindmapmode/ExtendedProgress25Action.java
@@ -29,8 +29,8 @@ class ExtendedProgress25Action extends AMultipleNodeAction {
 	 */
 	@Override
 	protected void actionPerformed(final ActionEvent e, final NodeModel node) {
-		final ViewerController vc = ((ViewerController) Controller.getCurrentController().getModeController()
-		    .getExtension(ViewerController.class));
+		final ViewerController vc = Controller.getCurrentController().getModeController()
+		    .getExtension(ViewerController.class);
 		try {
 	        URI uri = new URI(ResourceController.FREEPLANE_RESOURCE_URL_PROTOCOL, null, "/images/svg/Progress_quarter_00.svg", null);
 			vc.paste(uri, node);

--- a/freeplane/src/main/java/org/freeplane/view/swing/features/progress/mindmapmode/ProgressUtilities.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/features/progress/mindmapmode/ProgressUtilities.java
@@ -20,7 +20,7 @@ public class ProgressUtilities {
 	 * @return : true if the node has an external resource attached.
 	 */
 	public boolean hasExternalResource(final NodeModel node) {
-		final ExternalResource extResource = (ExternalResource) node.getExtension(ExternalResource.class);
+		final ExternalResource extResource = node.getExtension(ExternalResource.class);
 		if (extResource == null) {
 			return false;
 		}
@@ -34,7 +34,7 @@ public class ProgressUtilities {
 	 * @return : true if the node has an extended progress icon attached.
 	 */
 	public boolean hasExtendedProgressIcon(final NodeModel node) {
-		final ExternalResource extResource = (ExternalResource) node.getExtension(ExternalResource.class);
+		final ExternalResource extResource = node.getExtension(ExternalResource.class);
 		if (extResource == null) {
 			return false;
 		}

--- a/freeplane/src/main/java/org/freeplane/view/swing/features/progress/mindmapmode/RemoveProgressAction.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/features/progress/mindmapmode/RemoveProgressAction.java
@@ -34,8 +34,8 @@ class RemoveProgressAction extends AMultipleNodeAction {
 		}
 		//remove extended progress icon
 		if (progUtil.hasExtendedProgressIcon(node)) {
-			final ViewerController vc = ((ViewerController) Controller.getCurrentController().getModeController()
-			    .getExtension(ViewerController.class));
+			final ViewerController vc = Controller.getCurrentController().getModeController()
+			    .getExtension(ViewerController.class);
 			vc.undoableDeactivateHook(node);
 		}
 	}

--- a/freeplane/src/main/java/org/freeplane/view/swing/map/ViewLayoutTypeAction.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/ViewLayoutTypeAction.java
@@ -59,7 +59,7 @@ public class ViewLayoutTypeAction extends AFreeplaneAction {
 			map.setLayoutType(layoutType);
 			setSelected(true);
 		}
-		final MapStyle mapStyle = (MapStyle) map.getModeController().getExtension(MapStyle.class);
+		final MapStyle mapStyle = map.getModeController().getExtension(MapStyle.class);
 		mapStyle.setMapViewLayout(map.getModel(), map.getLayoutType());
 		map.getMapSelection().preserveNodeLocationOnScreen(map.getSelected().getModel(), 0.5f, 0.5f);
 		final NodeView root = map.getRoot();

--- a/freeplane/src/main/java/org/freeplane/view/swing/map/cloud/CloudView.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/cloud/CloudView.java
@@ -151,13 +151,13 @@ abstract public class CloudView {
         final Vector<Point> res = hull.calculateHull(coordinates);
         Point lastPt = null;
         for (int i = 0; i < res.size(); ++i) {
-            final Point pt = (Point) res.get(i);
+            final Point pt = res.get(i);
             if(!pt.equals(lastPt)){
                 p.addPoint(pt.x, pt.y);
                 lastPt = pt;
             }
         }
-        final Point pt = (Point) res.get(0);
+        final Point pt = res.get(0);
         p.addPoint(pt.x, pt.y);
         return p;
 	}

--- a/freeplane/src/main/java/org/freeplane/view/swing/map/cloud/ConvexHull.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/cloud/ConvexHull.java
@@ -118,28 +118,28 @@ class ConvexHull {
 		Point t;
 		min = 0;
 		for (i = 1; i < p.size(); ++i) {
-			if (((Point) p.get(i)).y < ((Point) p.get(min)).y) {
+			if (p.get(i).y < p.get(min).y) {
 				min = i;
 			}
 		}
 		for (i = 0; i < p.size(); ++i) {
-			if ((((Point) p.get(i)).y == ((Point) p.get(min)).y) && (((Point) p.get(i)).x > ((Point) p.get(min)).x)) {
+			if ((p.get(i).y == p.get(min).y) && (p.get(i).x > p.get(min).x)) {
 				min = i;
 			}
 		}
 		t = p.get(0);
 		p.set(0, p.get(min));
 		p.set(min, t);
-		final thetaComparator comp = new thetaComparator((Point) p.get(0));
+		final thetaComparator comp = new thetaComparator(p.get(0));
 		Collections.sort(p, comp);
-		p.add(0, new Point((Point) p.get(p.size() - 1)));
+		p.add(0, new Point(p.get(p.size() - 1)));
 		m = 3;
 		for (i = 4; i < p.size(); ++i) {
-			while (m > 0 && ccw((Point) p.get(m), (Point) p.get(m - 1), (Point) p.get(i)) >= 0) {
+			while (m > 0 && ccw(p.get(m), p.get(m - 1), p.get(i)) >= 0) {
 				m--;
 			}
 			m++;
-			t = (Point) p.get(m);
+			t = p.get(m);
 			p.set(m, p.get(i));
 			p.set(i, t);
 		}

--- a/freeplane/src/main/java/org/freeplane/view/swing/map/overview/MapOverviewImage.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/overview/MapOverviewImage.java
@@ -83,7 +83,7 @@ class MapOverviewImage extends JComponent {
         Dimension source = mapInnerBounds.getSize();
         Dimension target = overviewBounds.getSize();
         double scale = getBestScale(source, target);
-        if (image == null || image.getWidth() != (int) overviewBounds.width * scaleX) {
+        if (image == null || image.getWidth() != overviewBounds.width * scaleX) {
             image = createOverviewImage(mapInnerBounds, overviewBounds, scale);
         }
         double overviewImageX = (target.getWidth() - source.getWidth() * scale) / 2;

--- a/freeplane_api/src/main/java/org/freeplane/api/Quantity.java
+++ b/freeplane_api/src/main/java/org/freeplane/api/Quantity.java
@@ -17,7 +17,7 @@ public class Quantity <U extends Enum<U> & PhysicalUnit >{
 		if(separatorPosition >= 0){
 			numberString = valueString.substring(0, separatorPosition);
 			String unitString = valueString.substring(separatorPosition + 1);
-			final Class<U> unitClass = (Class<U>)defaultUnit.getDeclaringClass();
+			final Class<U> unitClass = defaultUnit.getDeclaringClass();
 			unit = Enum.valueOf(unitClass, unitString);
 		}
 		else {

--- a/freeplane_plugin_latex/src/main/java/org/freeplane/plugin/latex/DeleteLatexAction.java
+++ b/freeplane_plugin_latex/src/main/java/org/freeplane/plugin/latex/DeleteLatexAction.java
@@ -45,7 +45,7 @@ public class DeleteLatexAction extends AMultipleNodeAction {
 
 	@Override
 	protected void actionPerformed(final ActionEvent e, final NodeModel node) {
-		final LatexExtension latexExtension = (LatexExtension) node.getExtension(LatexExtension.class);
+		final LatexExtension latexExtension = node.getExtension(LatexExtension.class);
 		if (latexExtension != null) {
 			nodeHook.undoableDeactivateHook(node);
 			Controller.getCurrentModeController().getMapController()
@@ -57,6 +57,6 @@ public class DeleteLatexAction extends AMultipleNodeAction {
 	@Override
 	public void setEnabled() {
 		final NodeModel node = Controller.getCurrentModeController().getMapController().getSelectedNode();
-		setEnabled(node != null && (LatexExtension) node.getExtension(LatexExtension.class) != null);
+		setEnabled(node != null && node.getExtension(LatexExtension.class) != null);
 	}
 }

--- a/freeplane_plugin_latex/src/main/java/org/freeplane/plugin/latex/LatexNodeHook.java
+++ b/freeplane_plugin_latex/src/main/java/org/freeplane/plugin/latex/LatexNodeHook.java
@@ -109,7 +109,7 @@ class LatexNodeHook extends PersistentNodeHook implements INodeViewLifeCycleList
 
 	public void onViewCreated(final Container container) {
 		final NodeView nodeView = (NodeView) container;
-		final LatexExtension latexExtension = (LatexExtension) nodeView.getModel().getExtension(LatexExtension.class);
+		final LatexExtension latexExtension = nodeView.getModel().getExtension(LatexExtension.class);
 		if (latexExtension == null) {
 			return;
 		}
@@ -118,7 +118,7 @@ class LatexNodeHook extends PersistentNodeHook implements INodeViewLifeCycleList
 
 	public void onViewRemoved(final Container container) {
 		final NodeView nodeView = (NodeView) container;
-		final LatexExtension latexExtension = (LatexExtension) nodeView.getModel().getExtension(LatexExtension.class);
+		final LatexExtension latexExtension = nodeView.getModel().getExtension(LatexExtension.class);
 		if (latexExtension == null) {
 			return;
 		}
@@ -176,12 +176,12 @@ class LatexNodeHook extends PersistentNodeHook implements INodeViewLifeCycleList
 			return;
 		}
 		super.undoableToggleHook(node, null);
-		final LatexExtension latexExtension = (LatexExtension) node.getExtension(LatexExtension.class);
+		final LatexExtension latexExtension = node.getExtension(LatexExtension.class);
 		setEquationUndoable(latexExtension, equation);
 	}
 
 	void editLatexInEditor(final NodeModel node) {
-		LatexExtension latexExtension = (LatexExtension) node.getExtension(LatexExtension.class);
+		LatexExtension latexExtension = node.getExtension(LatexExtension.class);
 		final String equation;
 		//if no LaTeX is attached, create one
 		if (latexExtension == null) {

--- a/freeplane_plugin_openmaps/src/main/java/org/freeplane/plugin/openmaps/OpenMapsNodeHook.java
+++ b/freeplane_plugin_openmaps/src/main/java/org/freeplane/plugin/openmaps/OpenMapsNodeHook.java
@@ -38,7 +38,7 @@ public class OpenMapsNodeHook extends PersistentNodeHook implements LocationChoo
 	
 	public void removeLocationFromCurrentlySelectedNode() {
 		final NodeModel node = getCurrentlySelectedNode();
-		OpenMapsExtension openMapsExtension = (OpenMapsExtension) node.getExtension(OpenMapsExtension.class);
+		OpenMapsExtension openMapsExtension = node.getExtension(OpenMapsExtension.class);
 		
 		if (openMapsExtension != null) {
 			super.undoableToggleHook(node, openMapsExtension);
@@ -59,9 +59,9 @@ public class OpenMapsNodeHook extends PersistentNodeHook implements LocationChoo
 	public void viewCurrentlySelectedLocation(final NodeModel targetNode) {
 		OpenMapsExtension openMapsExtension;
 		if (targetNode == null)
-			openMapsExtension = (OpenMapsExtension) getCurrentlySelectedNode().getExtension(OpenMapsExtension.class);
+			openMapsExtension = getCurrentlySelectedNode().getExtension(OpenMapsExtension.class);
 		else
-			openMapsExtension = (OpenMapsExtension) targetNode.getExtension(OpenMapsExtension.class);
+			openMapsExtension = targetNode.getExtension(OpenMapsExtension.class);
 		
 		if (openMapsExtension != null) {
 			map = new OpenMapsDialog();
@@ -80,7 +80,7 @@ public class OpenMapsNodeHook extends PersistentNodeHook implements LocationChoo
 	protected IExtension createExtension(final NodeModel node, final XMLElement element) {
 		final OpenMapsExtension extension = new OpenMapsExtension();
 		loadLocationFromXML(element, extension);
-		return (IExtension) extension;
+		return extension;
 	}
 	
 	@Override
@@ -109,7 +109,7 @@ public class OpenMapsNodeHook extends PersistentNodeHook implements LocationChoo
 	
 	private void addChoosenLocationToSelectedNode(ICoordinate locationChoosen, int zoom) {
 		final NodeModel node = getCurrentlySelectedNode();
-		OpenMapsExtension openMapsExtension = (OpenMapsExtension) node.getExtension(OpenMapsExtension.class);
+		OpenMapsExtension openMapsExtension = node.getExtension(OpenMapsExtension.class);
 		
 		if (openMapsExtension == null) {
 			openMapsExtension = new OpenMapsExtension();

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/ScriptEditor.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/ScriptEditor.java
@@ -128,7 +128,7 @@ class ScriptEditor extends AFreeplaneAction {
 		}
 
 		public ScriptHolder getScript(final int pIndex) {
-			final Attribute attribute = ((AttributeHolder) mScripts.get(pIndex)).mAttribute;
+			final Attribute attribute = mScripts.get(pIndex).mAttribute;
 			return new ScriptHolder(attribute.getName(), attribute.getValue().toString());
 		}
 
@@ -137,7 +137,7 @@ class ScriptEditor extends AFreeplaneAction {
 		}
 
 		public void setScript(final int pIndex, final ScriptHolder pScript) {
-			final AttributeHolder oldHolder = (AttributeHolder) mScripts.get(pIndex);
+			final AttributeHolder oldHolder = mScripts.get(pIndex);
 			if (!pScript.mScriptName.equals(oldHolder.mAttribute.getName())) {
 				isDirty = true;
 			}

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/ScriptEditorProperty.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/ScriptEditorProperty.java
@@ -48,7 +48,7 @@ class ScriptEditorProperty extends PropertyBean implements IPropertyControl, Act
 	}
 
 	public void actionPerformed(final ActionEvent arg0) {
-		final IScriptEditorStarter plugin = (IScriptEditorStarter) Controller
+		final IScriptEditorStarter plugin = Controller
 				.getCurrentModeController().getExtension(
 						IScriptEditorStarter.class);
 		if (plugin != null) {

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/addons/AddOnInstallerPanel.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/addons/AddOnInstallerPanel.java
@@ -133,7 +133,7 @@ public class AddOnInstallerPanel extends JPanel {
 					final URL url = toURL(urlField.getText());
 					setStatusInfo(getText("status.installing"));
 					final ModeController modeController = controller.getModeController(MModeController.MODENAME);
-					final MFileManager fileManager = (MFileManager) MFileManager.getController(modeController);
+					final MFileManager fileManager = MFileManager.getController(modeController);
 					MapModel newMap = new MMapModel(modeController.getMapController().duplicator());
 					if (!fileManager.loadCatchExceptions(url, newMap)) {
 					    LogUtils.warn("can not load " + url);

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/ExternalObjectProxy.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/ExternalObjectProxy.java
@@ -20,7 +20,7 @@ class ExternalObjectProxy extends AbstractProxy<NodeModel> implements Proxy.Exte
     }
 
     private ExternalResource getExternalObjectModel() {
-        return (ExternalResource) getDelegate().getExtension(ExternalResource.class);
+        return getDelegate().getExtension(ExternalResource.class);
     }
 
     public String getUri() {

--- a/freeplane_plugin_svg/src/main/java/org/freeplane/plugin/svg/Activator.java
+++ b/freeplane_plugin_svg/src/main/java/org/freeplane/plugin/svg/Activator.java
@@ -30,7 +30,7 @@ public class Activator implements BundleActivator {
 			    	final ExportController exportController = ExportController.getController(modeController);
 			    	exportController.addMapExportEngine(new CaseSensitiveFileNameExtensionFilter("pdf", TextUtils.getText("export_pdf_text")), new ExportPdf());
 			    	exportController.addMapExportEngine(new CaseSensitiveFileNameExtensionFilter("svg", TextUtils.getText("export_svg_text")), new ExportSvg());
-				    final ViewerController extension = (ViewerController) modeController
+				    final ViewerController extension = modeController
 				        .getExtension(ViewerController.class);
 				    extension.addFactory(new SvgViewerFactory());
 			    }


### PR DESCRIPTION
There are around 1000 build warnings. This PR solves ~120 of them. This solves all the warnings of type `[cast] redundant cast to type`. My next commit will remove large part of using deprecated methods/fields. I'd like to keep the build process without unnecessary warnings.