### PR TITLE
Corrected compilation warnings: .toURI() -> .toURI().toURL()

### DIFF
--- a/freeplane/src/main/java/org/freeplane/core/util/Compat.java
+++ b/freeplane/src/main/java/org/freeplane/core/util/Compat.java
@@ -49,7 +49,7 @@ public class Compat {
 	}
 
 	public static URL fileToUrl(final File pFile) throws MalformedURLException {
-		return pFile.toURL();
+		return pFile.toURI().toURL();
 	}
 
 	public static boolean isLowerJdk(final String version) {

--- a/freeplane/src/main/java/org/freeplane/features/filter/FilterController.java
+++ b/freeplane/src/main/java/org/freeplane/features/filter/FilterController.java
@@ -714,7 +714,7 @@ public class FilterController implements IExtension, IMapViewChangeListener {
 			File filterFile = new File(pathToFilterFile);
 			final IXMLReader reader = new StdXMLReader(new BufferedInputStream(new FileInputStream(filterFile)));
 			parser.setReader(reader);
-			reader.setSystemID(filterFile.toURL().toString());
+			reader.setSystemID(filterFile.toURI().toURL().toString());
 			final XMLElement loader = (XMLElement) parser.parse();
 			final Vector<XMLElement> conditions = loader.getChildren();
 			for (int i = 0; i < conditions.size(); i++) {

--- a/freeplane/src/main/java/org/freeplane/features/icon/mindmapmode/IconSelectionPlugin.java
+++ b/freeplane/src/main/java/org/freeplane/features/icon/mindmapmode/IconSelectionPlugin.java
@@ -82,6 +82,6 @@ public class IconSelectionPlugin extends AFreeplaneAction {
 			}
 
 		});
-		selectionDialog.show();
+		selectionDialog.setVisible(true);
 	}
 }

--- a/freeplane/src/main/java/org/freeplane/features/map/mindmapmode/MMapController.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/mindmapmode/MMapController.java
@@ -971,7 +971,7 @@ public class MMapController extends MapController {
             return;
         }
         try {
-            final URL endUrl = localFile.toURL();
+            final URL endUrl = localFile.toURI().toURL();
             try {
                 if (endUrl.getFile().endsWith(".mm")) {
                     Controller.getCurrentController().selectMode(MModeController.MODENAME);

--- a/freeplane/src/main/java/org/freeplane/features/mode/PersistentNodeHook.java
+++ b/freeplane/src/main/java/org/freeplane/features/mode/PersistentNodeHook.java
@@ -82,7 +82,7 @@ public abstract class PersistentNodeHook {
         private static final long serialVersionUID = 1L;
         final Enum<?> value;
         public SelectableEnumAction(String key, final Enum<?> value) {
-            super(key + "." + String.valueOf(value));
+            super(key + "." + value);
             this.value = value;
         }
 

--- a/freeplane/src/main/java/org/freeplane/features/mode/mindmapmode/LoadAcceleratorPresetsAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/mode/mindmapmode/LoadAcceleratorPresetsAction.java
@@ -101,7 +101,7 @@ public class LoadAcceleratorPresetsAction extends AFreeplaneAction {
 						final String key = "LoadAcceleratorPresetsAction." + propName;
 							final String title = TextUtils.getText(key + ".text", propName);
 							final LoadAcceleratorPresetsAction loadAcceleratorPresetsAction = new LoadAcceleratorPresetsAction(
-							    prop.toURL(), key, title);
+							    prop.toURI().toURL(), key, title);
 						modeController.addActionIfNotAlreadySet(loadAcceleratorPresetsAction);
 						new EntryAccessor().addChildAction(target, loadAcceleratorPresetsAction);
 					}

--- a/freeplane/src/main/java/org/freeplane/features/text/mindmapmode/EditNodeBase.java
+++ b/freeplane/src/main/java/org/freeplane/features/text/mindmapmode/EditNodeBase.java
@@ -207,7 +207,7 @@ abstract public class EditNodeBase {
 		}
 
 		public void show() {
-	        dialog.show();
+	        dialog.setVisible(true);;
         }
 
 		public void dispose() {

--- a/freeplane/src/main/java/org/freeplane/main/application/ApplicationResourceController.java
+++ b/freeplane/src/main/java/org/freeplane/main/application/ApplicationResourceController.java
@@ -192,11 +192,11 @@ public class ApplicationResourceController extends ResourceController {
 					try {
 						final File try1 = new File(rootDir + "/plugins/org.freeplane.core/lib/freeplaneviewer.jar");
 						if (try1.exists()) {
-							return try1.toURL();
+							return try1.toURI().toURL();
 						}
 						final File try2 = new File(rootDir + "/lib/freeplaneviewer.jar");
 						if (try2.exists()) {
-							return try2.toURL();
+							return try2.toURI().toURL();
 						}
 					}
 					catch (final MalformedURLException e) {

--- a/freeplane/src/test/java/org/freeplane/features/presentations/mindmapmode/MainFrame.java
+++ b/freeplane/src/test/java/org/freeplane/features/presentations/mindmapmode/MainFrame.java
@@ -36,6 +36,6 @@ public class MainFrame {
 		presentationEditorController.setPresentations(new NamedElementCollection<>(presentationFactory));
 		frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		frame.pack();
-		frame.show();
+		frame.setVisible(true);
 	}
 }

--- a/freeplane/src/test/java/org/freeplane/main/application/survey/SurveyStarterShould.java
+++ b/freeplane/src/test/java/org/freeplane/main/application/survey/SurveyStarterShould.java
@@ -95,7 +95,7 @@ public class SurveyStarterShould {
 		try (final FileOutputStream propertyStream = new FileOutputStream(configFile)){
 			configProperties.store(propertyStream, "");
 		}
-		final URL configurationUrl = configFile.toURL();
+		final URL configurationUrl = configFile.toURI().toURL();
 		FreeplaneSurveyProperties freeplaneSurveyProperties = mock(FreeplaneSurveyProperties.class);
 		when(freeplaneSurveyProperties.openRemoteConfiguration()).thenAnswer(new Answer<InputStream>() {
 

--- a/freeplane_plugin_bugreport/src/main/java/org/freeplane/plugin/bugreport/ReportGenerator.java
+++ b/freeplane_plugin_bugreport/src/main/java/org/freeplane/plugin/bugreport/ReportGenerator.java
@@ -197,7 +197,7 @@ public class ReportGenerator extends StreamHandler {
 			if (file.isDirectory()) {
 				final ViewController viewController = Controller.getCurrentController().getViewController();
 				try {
-					viewController.openDocument(file.toURL());
+					viewController.openDocument(file.toURI().toURL());
 				}
 				catch (Exception ex) {
 				}

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/ScriptContext.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/ScriptContext.java
@@ -49,7 +49,7 @@ public class ScriptContext implements AccessedNodes{
 		try {
 			File file = new File(path);
 			if(file.isAbsolute()) {
-				return file.getCanonicalFile().toURL();
+				return file.getCanonicalFile().toURI().toURL();
 			}
 			else  {
 				URL baseUrl = getBaseUrl();
@@ -57,7 +57,7 @@ public class ScriptContext implements AccessedNodes{
 					return new URL(baseUrl, path);
 				}
 				else
-					return file.getCanonicalFile().toURL();
+					return file.getCanonicalFile().toURI().toURL();
 			}
 		}
 		catch (IOException e) {


### PR DESCRIPTION
This change fixes the deprecation of File.toURL()
File.toURL is deprecated:
https://docs.oracle.com/javase/7/docs/api/java/io/File.html#toURL()

and few `show()` -> `setVisible(true)`