### PR TITLE
change download url for java

### DIFF
--- a/freeplane_framework/launch4j/freeplaneConsole.lj4.xml
+++ b/freeplane_framework/launch4j/freeplaneConsole.lj4.xml
@@ -8,7 +8,7 @@
   <cmdLine></cmdLine>
   <chdir></chdir>
   <priority>normal</priority>
-  <downloadUrl>http://java.com/download</downloadUrl>
+  <downloadUrl>https://www.azul.com/downloads/?version=java-15-mts&amp;os=windows&amp;package=jre#download-openjdk</downloadUrl>
   <supportUrl></supportUrl>
   <stayAlive>true</stayAlive>
   <restartOnCrash>false</restartOnCrash>

--- a/freeplane_framework/launch4j/freeplaneGui.lj4.xml
+++ b/freeplane_framework/launch4j/freeplaneGui.lj4.xml
@@ -8,7 +8,7 @@
   <cmdLine></cmdLine>
   <chdir></chdir>
   <priority>normal</priority>
-  <downloadUrl>http://java.com/download</downloadUrl>
+  <downloadUrl>https://www.azul.com/downloads/?version=java-15-mts&amp;os=windows&amp;package=jre#download-openjdk</downloadUrl>
   <supportUrl></supportUrl>
   <stayAlive>true</stayAlive>
   <restartOnCrash>false</restartOnCrash>


### PR DESCRIPTION
When Launch4j redirects to http://java.com/download, which offers only JRE 8, User is lost and goes on to download and install JRE 8, despite the initial warning: "The application requires a Java Runtime Environment 11 - 17"

The new link redirects to Zulu JRE 15, like the one used in Freeplane-Setup-with-Java.exe