### PR TITLE
Feature 700/insert condi

### DIFF
--- a/freeplane/src/main/java/org/freeplane/features/styles/mindmapmode/MLogicalStyleController.java
+++ b/freeplane/src/main/java/org/freeplane/features/styles/mindmapmode/MLogicalStyleController.java
@@ -138,7 +138,7 @@ public class MLogicalStyleController extends LogicalStyleController {
 
 		@Override
 		public void undo() {
-			int index = conditionalStyleModel.getStyleCount() - 1;
+			int index = this.index == -1 ? conditionalStyleModel.getStyleCount() - 1 : this.index;
 			MLogicalStyleController.super.removeConditionalStyle(conditionalStyleModel, index);
 		}
 


### PR DESCRIPTION
1. fix a bug in undo add/insert
2. add/insert/remove conditionalStyle were apparently created to be used by the Manage Conditional Styles Action (dialog) and lack the call to nodeChanged, because it is done after the dialog is closed.
This PR adds methods which call nodeChanged. They will be used by the upcoming scripting API.