### PR TITLE
Create initial CI configuration with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Build and Test
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'  # Each Monday at 06:00 UTC
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        java-version: ['17', '18']
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java-version }}
+    - run: gradle build --info
+    - run: gradle -PTestLoggingFull=true check_translation check


### PR DESCRIPTION
Create an initial CI configuration with GitHub Actions. It builds and checks Freeplane, currently on Java 17 and 18 on Ubuntu.

It runs on each push and pull request, when manually triggered and once a week on the default branch.

GitHub Actions needs to be activated at https://github.com/freeplane/freeplane/actions. A sample run can be [found here](https://github.com/EwoutH/freeplane/actions/runs/3530873584).

It's based on the current Travis CI configuration: https://github.com/freeplane/freeplane/blob/1.10.x/.travis.yml