### PR TITLE
Support gradle 8.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 plugins {
-  id 'nebula.ospackage' version '9.1.1'
+  id 'com.netflix.nebula.ospackage' version '11.0.0'
   id 'org.owasp.dependencycheck' version '7.0.0' apply false
   id 'se.patrikerdes.use-latest-versions' version '0.2.18'  apply false
   id 'com.github.ben-manes.versions' version '0.42.0'  apply false

--- a/freeplane/build.gradle
+++ b/freeplane/build.gradle
@@ -58,6 +58,7 @@ test {
 		sourceSets.viewer.resources.sourceDirectories +
  		sourceSets.editor.resources.sourceDirectories +
  		sourceSets.external.resources.sourceDirectories
+    dependsOn createEmojiList
 }
 
 targetCompatibility=JavaVersion.VERSION_1_8
@@ -253,6 +254,9 @@ task copyOSGiJars(type: Copy) {
     from (project(':freeplane_mac').jar.outputs.files)
     from (project(':freeplane_api').file('build/libs/freeplaneapi_viewer.jar'))
     into(globalBin + '/core/' + pluginid + '/lib/')
+    dependsOn(':freeplane:editorJar')
+    dependsOn(':freeplane:osgiJar')
+    dependsOn(':freeplane:viewerJar')
 }
 copyOSGiJars.dependsOn tasks.getByPath(':freeplane_mac:jar')
 copyOSGiJars.dependsOn tasks.getByPath(':freeplane_api:viewerApiJar')
@@ -360,6 +364,8 @@ task copyExternalResources(type: Copy) {
     dependsOn copyGitTxt
     dependsOn copyGitProperty
     dependsOn createGitProperty
+    dependsOn(':srcTarGz')
+    dependsOn(':srcpureTarGz')
 }
 
 task copyDoc(type: Copy) {

--- a/freeplane_framework/build.gradle
+++ b/freeplane_framework/build.gradle
@@ -43,6 +43,7 @@ task copyFreeplaneShellScript(type: Copy) {
      }
 	 into(globalBin)
 	 filter(FixCrLfFilter.class, eol:FixCrLfFilter.CrLf.newInstance("lf"))
+     dependsOn(':srcTarGz')
 }	 
 
 ext {launch4jDir = 'C:/Program Files (x86)/Launch4j'}
@@ -94,6 +95,7 @@ task copyLauncherStuff(type: Copy) {
      }
      into(globalBin)
      dependsOn jar
+     dependsOn(':srcTarGz')
 }
 
 eclipseJdt {


### PR DESCRIPTION
Probably backport in 1.11.x as well since both branches are affected.

version 10.0.0 changed the namespace
version 11.0.0 adds supports for gradle 8.x

https://github.com/nebula-plugins/gradle-ospackage-plugin/releases

@dpolivaev Not sure if you want to handle the `dependsOn` that way, that's why it's a separate commit.
