### PR TITLE
Feature/uri friendly decoded string

### DIFF
--- a/freeplane/src/main/java/org/freeplane/core/util/Hyperlink.java
+++ b/freeplane/src/main/java/org/freeplane/core/util/Hyperlink.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 public class Hyperlink {
 	private URI uri;
 	private String uriString;
+	private String uriFriendlyDecodedString;
 
     public Hyperlink(URI uri) {
         super();
@@ -46,6 +47,17 @@ public class Hyperlink {
 		if(uriString == null)
 			uriString = uri.toString();
 		return uriString;
+	}
+
+	public String toUriFriendlyDecodedString() {
+		if (uriFriendlyDecodedString == null)
+			uriFriendlyDecodedString = makeUriConstructorFriendlyDecodedString();
+		return uriFriendlyDecodedString;
+	}
+	private String makeUriConstructorFriendlyDecodedString() {
+		String scheme = uri.getScheme();
+		String fragment = uri.getFragment();
+		return (scheme != null ? scheme + ":" : "") + uri.getSchemeSpecificPart() + (fragment != null ? "#" + fragment : "");
 	}
 
 	public String getScheme() {

--- a/freeplane/src/main/java/org/freeplane/features/link/LinkController.java
+++ b/freeplane/src/main/java/org/freeplane/features/link/LinkController.java
@@ -141,6 +141,9 @@ public class LinkController extends SelectionController implements IExtension {
 			try {
 				String string = (String)object;
 				if(string.startsWith("#")) {
+					try {
+						string = LinkController.createHyperlink(string).toUriFriendlyDecodedString();
+					} catch (URISyntaxException ignore) {}
 					String reference = string.substring(1);
 			        final MapExplorerController explorer = modeController.getExtension(MapExplorerController.class);
 			        final NodeModel dest = explorer.getNodeAt(node, reference);
@@ -449,7 +452,7 @@ public class LinkController extends SelectionController implements IExtension {
 		if (link == null) {
 			return null;
 		}
-		final String adaptedText = link.toString();
+		final String adaptedText = link.toUriFriendlyDecodedString();
 		if (adaptedText.startsWith("#")) {
 			ModeController modeController = Controller.getCurrentModeController();
 			final MapExplorerController explorer = modeController.getExtension(MapExplorerController.class);
@@ -1084,7 +1087,7 @@ public class LinkController extends SelectionController implements IExtension {
 	}
 
 	public void loadURI(NodeModel node, Hyperlink uri) {
-		final String uriString = uri.toString();
+		final String uriString = uri.toUriFriendlyDecodedString();
 		if (uriString.startsWith("#")) {
 			String reference = uriString.substring(1);
 			UrlManager.getController().selectNode(node, reference);

--- a/freeplane/src/main/java/org/freeplane/features/link/LinkController.java
+++ b/freeplane/src/main/java/org/freeplane/features/link/LinkController.java
@@ -757,13 +757,18 @@ public class LinkController extends SelectionController implements IExtension {
 	static Pattern patURI = Pattern.compile( // [scheme:]scheme-specific-part[#fragment]
 	    "(?:(\\p{Alpha}[\\p{Alnum}+.-]+):)?(.*?)(?:#([^#]*))?");
 
+	public static Hyperlink createHyperlink(final String inputValue) throws URISyntaxException {
+		return createHyperlink(inputValue, true);
+	}
+
 	/* Function that tries to transform a not necessarily well-formed
 	 * string into a valid URI. We use the fact that the single-argument
 	 * URI constructor doesn't escape invalid characters (especially
 	 * spaces), whereas the 3-argument constructors does do escape
 	 * them (e.g. space into %20).
+	 * keepOriginalString has effect only for non-smb and non-file URIs
 	 */
-	public static Hyperlink createHyperlink(final String inputValue) throws URISyntaxException {
+	public static Hyperlink createHyperlink(final String inputValue, boolean keepOriginalString) throws URISyntaxException {
 		try { // first, we try if the string can be interpreted as URI
 			return new Hyperlink(inputValue, new URI(inputValue));
 		}
@@ -810,7 +815,11 @@ public class LinkController extends SelectionController implements IExtension {
 					final String scheme = mat.group(1);
 					final String ssp = mat.group(2).replace('\\', '/');
 					final String fragment = mat.group(3);
-					return new Hyperlink(inputValue, new URI(scheme, ssp, fragment));
+					final URI uri = new URI(scheme, ssp, fragment);
+					if (keepOriginalString)
+						return new Hyperlink(inputValue, uri);
+					else
+						return new Hyperlink(uri);
 				}
 			}
 			throw new URISyntaxException(inputValue, "This doesn't look like a valid link (URI, file, SMB or URL).");

--- a/freeplane/src/main/java/org/freeplane/features/link/LinkTransformer.java
+++ b/freeplane/src/main/java/org/freeplane/features/link/LinkTransformer.java
@@ -20,6 +20,7 @@
 package org.freeplane.features.link;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 
 import javax.swing.Icon;
 
@@ -53,9 +54,12 @@ public class LinkTransformer extends AbstractContentTransformer {
 			return content;
 		if(! ( content instanceof Hyperlink ||  content instanceof URI))
 			return content;
-		final String string = content.toString();
+		String string = content.toString();
 		if(! string.startsWith("#"))
 			return content;
+		try {
+			string = LinkController.createHyperlink(string).toUriFriendlyDecodedString();
+		} catch (URISyntaxException ignore) {}
 		final String reference=string.substring(1);
 		final NodeModel target = modeController.getExtension(MapExplorerController.class).getNodeAt(node, reference);
 		if(target != null){

--- a/freeplane/src/main/java/org/freeplane/features/link/NodeLinks.java
+++ b/freeplane/src/main/java/org/freeplane/features/link/NodeLinks.java
@@ -71,6 +71,11 @@ public class NodeLinks implements IExtension {
 		return link != null ? link.toString() : null;
 	}
 
+	public static String getLinkAsUriFriendlyDecodedString(final NodeModel selectedNode) {
+		final Hyperlink link = NodeLinks.getValidLink(selectedNode);
+		return link != null ? link.toUriFriendlyDecodedString() : null;
+	}
+
 	/**
 	 * @param node
 	 * @return

--- a/freeplane/src/main/java/org/freeplane/features/link/mindmapmode/SetLinkByTextFieldAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/link/mindmapmode/SetLinkByTextFieldAction.java
@@ -56,7 +56,7 @@ class SetLinkByTextFieldAction extends AFreeplaneAction {
 	public void actionPerformed(final ActionEvent e) {
 		final ModeController modeController = Controller.getCurrentModeController();
 		final NodeModel selectedNode = modeController.getMapController().getSelectedNode();
-		String linkAsString = NodeLinks.getLinkAsString(selectedNode);
+		String linkAsString = NodeLinks.getLinkAsUriFriendlyDecodedString(selectedNode);
 		if(Compat.isWindowsOS() && linkAsString != null && linkAsString.startsWith("smb:")){
 			final Hyperlink link = NodeLinks.getValidLink(selectedNode);
 			linkAsString = Compat.smbUri2unc(link.getUri());

--- a/freeplane/src/main/java/org/freeplane/features/map/GotoNodeAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/GotoNodeAction.java
@@ -20,6 +20,7 @@
 package org.freeplane.features.map;
 
 import java.awt.event.ActionEvent;
+import java.net.URISyntaxException;
 
 import javax.swing.Action;
 import javax.swing.JOptionPane;
@@ -28,6 +29,7 @@ import org.freeplane.core.ui.AFreeplaneAction;
 import org.freeplane.core.ui.components.UITools;
 import org.freeplane.core.util.TextUtils;
 import org.freeplane.features.explorer.MapExplorerController;
+import org.freeplane.features.link.LinkController;
 import org.freeplane.features.mode.Controller;
 
 /**
@@ -63,7 +65,11 @@ public class GotoNodeAction extends AFreeplaneAction {
     private String getReference(String reference) {
         if(reference.startsWith("ID_") || reference.startsWith("at("))
             return reference;
-        else
+        else {
+            try {
+                reference = LinkController.createHyperlink(reference).toUriFriendlyDecodedString();
+            } catch (URISyntaxException ignore) {}
             return "at(" + reference + ")";
+        }
     }
 }

--- a/freeplane/src/main/java/org/freeplane/features/map/GotoNodeAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/GotoNodeAction.java
@@ -20,6 +20,7 @@
 package org.freeplane.features.map;
 
 import java.awt.event.ActionEvent;
+import java.net.URI;
 import java.net.URISyntaxException;
 
 import javax.swing.Action;
@@ -67,7 +68,7 @@ public class GotoNodeAction extends AFreeplaneAction {
             return reference;
         else {
             try {
-                reference = LinkController.createHyperlink(reference).toUriFriendlyDecodedString();
+                reference = new URI(null, "", reference).getFragment();
             } catch (URISyntaxException ignore) {}
             return "at(" + reference + ")";
         }

--- a/freeplane/src/main/java/org/freeplane/features/map/MapController.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/MapController.java
@@ -60,6 +60,7 @@ import org.freeplane.features.explorer.MapExplorerController;
 import org.freeplane.features.filter.Filter;
 import org.freeplane.features.filter.FilterController;
 import org.freeplane.features.filter.condition.ConditionFactory;
+import org.freeplane.features.link.LinkController;
 import org.freeplane.features.map.MapWriter.Mode;
 import org.freeplane.features.map.NodeModel.NodeChangeType;
 import org.freeplane.features.map.NodeModel.Side;
@@ -860,6 +861,7 @@ implements IExtension, NodeChangeAnnouncer{
 	    String nodeReference = url.getRef();
 	    if(nodeReference != null){
 	    	openMap(new URL(url.getProtocol(), url.getHost(), url.getPort(), url.getPath()));
+		    nodeReference =  LinkController.createHyperlink(nodeReference).toUriFriendlyDecodedString();
 	    	final NodeModel node = getNodeAt(nodeReference);
 	    	if(node != null)
 	    		select(node);

--- a/freeplane/src/main/java/org/freeplane/features/text/mindmapmode/SHTMLEditLinkAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/text/mindmapmode/SHTMLEditLinkAction.java
@@ -63,7 +63,7 @@ public class SHTMLEditLinkAction extends AFreeplaneAction implements SHTMLAction
 				return;
 			}
 			try {
-				final Hyperlink link = LinkController.createHyperlink(inputValue.trim());
+				final Hyperlink link = LinkController.createHyperlink(inputValue.trim(), false);
 				editor.setLink(null, link.toString(), null);
 			}
 			catch (final URISyntaxException e1) {

--- a/freeplane/src/main/java/org/freeplane/features/text/mindmapmode/SHTMLEditLinkAction.java
+++ b/freeplane/src/main/java/org/freeplane/features/text/mindmapmode/SHTMLEditLinkAction.java
@@ -36,13 +36,17 @@ public class SHTMLEditLinkAction extends AFreeplaneAction implements SHTMLAction
         SHTMLEditorPane editorPane = panel.getSHTMLEditorPane();
 		final Element linkElement = editorPane.getCurrentLinkElement();
         final boolean foundLink = (linkElement != null);
-		final String linkAsString;
+		String linkAsString;
         if (foundLink) {
             final AttributeSet elemAttrs = linkElement.getAttributes();
             final Object linkAttr = elemAttrs.getAttribute(HTML.Tag.A);
             final Object href = ((AttributeSet) linkAttr).getAttribute(HTML.Attribute.HREF);
             if (href != null) {
-            	linkAsString = href.toString();
+	            try {
+		            linkAsString = LinkController.createHyperlink(href.toString()).toUriFriendlyDecodedString();
+	            } catch (URISyntaxException e) {
+		            linkAsString = href.toString();
+	            }
             }
             else
             	linkAsString = "http://";

--- a/freeplane/src/main/java/org/freeplane/features/url/UrlManager.java
+++ b/freeplane/src/main/java/org/freeplane/features/url/UrlManager.java
@@ -268,7 +268,7 @@ public class UrlManager implements IExtension {
     /**@deprecated -- use LinkController*/
 	@Deprecated
 	public void loadHyperlink(Hyperlink link) {
-		final String uriString = link.toString();
+		final String uriString = link.toUriFriendlyDecodedString();
 		if (uriString.startsWith("#")) {
 			loadLocalLinkURI(uriString);
 		}

--- a/freeplane/src/main/java/org/freeplane/view/swing/map/attribute/AttributePopupMenu.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/attribute/AttributePopupMenu.java
@@ -185,7 +185,13 @@ class AttributePopupMenu extends JPopupMenu implements MouseListener {
 				public void actionPerformed(final ActionEvent e) {
 					final AttributeTable table = AttributePopupMenu.this.table;
 					final Object oldValue = table.getValueAt(row, col);
-					final String inputValue = JOptionPane.showInputDialog(table, TextUtils.getText("edit_link_manually"), oldValue.toString());
+					String oldString;
+					try {
+						oldString = LinkController.createHyperlink(oldValue.toString()).toUriFriendlyDecodedString();
+					} catch (URISyntaxException ex) {
+						oldString = oldValue.toString();
+					}
+					final String inputValue = JOptionPane.showInputDialog(table, TextUtils.getText("edit_link_manually"), oldString);
 					if (inputValue != null && (oldValue instanceof String || ! oldValue.equals(inputValue))) {
 						if (inputValue.toString().equals("")) {
 							table.setValueAt("", row, col);

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/LinkProxy.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/LinkProxy.java
@@ -61,10 +61,10 @@ class LinkProxy extends AbstractProxy<NodeModel> implements Proxy.Link {
 	// LinkRO
 	@Override
 	public Node getNode() {
-		final URI uri = getUri();
-		if (uri == null)
+		final Hyperlink hyperlink = NodeLinks.getLink(getDelegate());
+		if (hyperlink == null)
 			return null;
-		final String link = uri.toString();
+		final String link = hyperlink.toUriFriendlyDecodedString();
 		if (!link.startsWith("#")) {
 			return null;
 		}


### PR DESCRIPTION
Please see commit messages for explanations.

Here's a mind map showing the issue with `#at(...)`
[test-FP1243-decode at for execution and uri for editing.mm.zip](https://github.com/freeplane/freeplane/files/11857802/test-FP1243-decode.at.for.execution.and.uri.for.editing.mm.zip)
