### PR TITLE
Feature/markdown hard line breaks

### DIFF
--- a/freeplane/src/main/java/org/freeplane/core/util/HtmlUtils.java
+++ b/freeplane/src/main/java/org/freeplane/core/util/HtmlUtils.java
@@ -153,9 +153,10 @@ public class HtmlUtils {
 			        Pattern.compile("(?ims)&lt;"),
 			        Pattern.compile("(?ims)&gt;"),
 			        Pattern.compile("(?ims)&quot;"),
-			        Pattern.compile("(?ims)&nbsp;"),
 			        Pattern.compile("(?ims)&amp;"),
-			        Pattern.compile("(?ims)[ \t]+\n") };
+					Pattern.compile("(?ims)[ \t]+\n"),
+					Pattern.compile("(?ims)&nbsp;")
+			};
 		}
 		String intermediate = text;
 		int i = 0;
@@ -184,9 +185,9 @@ public class HtmlUtils {
 		intermediate = PATTERNS[i++].matcher(intermediate).replaceAll("<");
 		intermediate = PATTERNS[i++].matcher(intermediate).replaceAll(">");
 		intermediate = PATTERNS[i++].matcher(intermediate).replaceAll("\"");
-		intermediate = PATTERNS[i++].matcher(intermediate).replaceAll(" ");
 		intermediate = PATTERNS[i++].matcher(intermediate).replaceAll("&");
 		intermediate = PATTERNS[i++].matcher(intermediate).replaceAll("\n");
+		intermediate = PATTERNS[i++].matcher(intermediate).replaceAll(" ");
 		intermediate = intermediate.replace('\u00a0', ' ');
 		return intermediate;
 	}

--- a/freeplane/src/test/java/org/freeplane/core/util/HtmlUtilsTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/util/HtmlUtilsTest.java
@@ -1,0 +1,61 @@
+package org.freeplane.core.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class HtmlUtilsTest {
+
+	@Test
+	public void testHtmlToPlain_shouldRemoveTrailingWhitespaces() {
+		String input = "<html>\n" +
+				"  <head>\n" +
+				"    \n" +
+				"  </head>\n" +
+				"  <body>\n" +
+				"    <p>\n" +
+				"      A paragraph followed by an empty one\n" +
+				"    </p>\n" +
+				"    <p>\n" +
+				"      \n" +
+				"    </p>\n" +
+				"  </body>\n" +
+				"</html>";
+		String expected = "A paragraph followed by an empty one";
+		String actual = HtmlUtils.htmlToPlain(input, true, true);
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testHtmlToPlain_shouldRetainTrailingNonBreakingSpaces() {
+		String input = "<html>\n" +
+				"  <head>\n" +
+				"    \n" +
+				"  </head>\n" +
+				"  <body>\n" +
+				"    <p>\n" +
+				"      Zero\n" +
+				"    </p>\n" +
+				"    <p>\n" +
+				"      One&nbsp; \n" +
+				"    </p>\n" +
+				"    <p>\n" +
+				"      Two&nbsp;&nbsp; \n" +
+				"    </p>\n" +
+				"    <p>\n" +
+				"      Three&nbsp;&nbsp;&nbsp; \n" +
+				"    </p>\n" +
+				"    <p>\n" +
+				"      EOF\n" +
+				"    </p>\n" +
+				"  </body>\n" +
+				"</html>\n";
+		String expected = "Zero\n" +
+				"One \n" +
+				"Two  \n" +
+				"Three   \n" +
+				"EOF";
+		String actual = HtmlUtils.htmlToPlain(input, true, true);
+		assertEquals(expected, actual);
+	}
+}

--- a/freeplane_plugin_markdown/build.gradle
+++ b/freeplane_plugin_markdown/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     implementation project(':freeplane')
     implementation project(':freeplane_plugin_jsyntaxpane')
-    lib 'io.github.gitbucket:markedj:1.0.17'
+    lib 'io.github.gitbucket:markedj:1.0.18'
 }
 
 ext.bundleImports = 'de.sciss.syntaxpane.*'


### PR DESCRIPTION
- fix htmlToPlain to retain trailing NBSPs so that trailing spaces (nbsp) are respected, which is one of the methods to indicate a hard line break in markdown
- bump markedj version because 1.0.18 includes a fix for hard line breaks by backslash at EOL -> https://github.com/gitbucket/markedj/pull/41