### PR TITLE
fix NPE when text is null

### DIFF
--- a/freeplane/src/main/java/org/freeplane/core/util/HtmlUtils.java
+++ b/freeplane/src/main/java/org/freeplane/core/util/HtmlUtils.java
@@ -112,6 +112,9 @@ public class HtmlUtils {
 	/** equivalent to htmlToPlain(text, strictHTMLOnly=true, removeNewLines=true)
 	 * @see #htmlToPlain(String, boolean, boolean) */
 	public static String htmlToPlain(final String text) {
+		if (text == null) {
+			return null;
+		}
 		CachedStringTransformationResult threadLocalCachedHtmlToPlain = cachedHtmlToPlain.get();
 		if(threadLocalCachedHtmlToPlain.input.equals(text))
 			return threadLocalCachedHtmlToPlain.output;


### PR DESCRIPTION
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "threadLocalCachedHtmlToPlain.input" is null
	at org.freeplane.core.util.HtmlUtils.htmlToPlain(HtmlUtils.java:116)

### Test Case
[api-groovy-tutorial.xi.zip](https://github.com/freeplane/freeplane/files/12139611/api-groovy-tutorial.xi.zip)
- Enable Map Conditional Style in the attached mind map

