### PR TITLE
fix image uri when linkType==relative

### DIFF
--- a/freeplane/src/main/java/org/freeplane/view/swing/features/filepreview/ViewerController.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/features/filepreview/ViewerController.java
@@ -778,27 +778,20 @@ public class ViewerController extends PersistentNodeHook implements INodeViewLif
 			return false;
 		}
 		File file = new File(uri.getPath());
-		final File mapFile = targetNode.getMap().getFile();
-		if (!file.isAbsolute()) {
-			if (mapFile == null) {
-				showWarningMapNotSaved();
-				return false;
-			}
-			file = new File(mapFile.getParent(), uri.getPath());
-		}
-		if (uri.getScheme() == null || uri.getScheme().equals("file")) {
+		boolean isFile = uri.getScheme().equals("file");
+		if (isFile) {
 	        if (!file.exists()) {
 	        	return false;
 	        }
+	        final File mapFile = targetNode.getMap().getFile();
 	        if (mapFile == null && LinkController.getLinkType() == LinkController.LINK_RELATIVE_TO_MINDMAP) {
-				showWarningMapNotSaved();
+	        	JOptionPane.showMessageDialog(KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner(),
+	        		TextUtils.getText("not_saved_for_image_error"), "Freeplane", JOptionPane.WARNING_MESSAGE);
 	        	return false;
 	        }
 	        if (LinkController.getLinkType() != LinkController.LINK_ABSOLUTE) {
 	        	uri = LinkController.toLinkTypeDependantURI(mapFile, file);
-			} else {
-				uri = file.toURI();
-			}
+	        }
         }
 		final MMapController mapController = (MMapController) Controller.getCurrentModeController().getMapController();
 		final NodeModel node;
@@ -821,9 +814,4 @@ public class ViewerController extends PersistentNodeHook implements INodeViewLif
 	public IViewerFactory getViewerFactory() {
 	    return combiFactory;
     }
-
-	private void showWarningMapNotSaved() {
-		JOptionPane.showMessageDialog(KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner(),
-				TextUtils.getText("not_saved_for_image_error"), "Freeplane", JOptionPane.WARNING_MESSAGE);
-	}
 }

--- a/freeplane/src/main/java/org/freeplane/view/swing/features/filepreview/ViewerController.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/features/filepreview/ViewerController.java
@@ -804,12 +804,17 @@ public class ViewerController extends PersistentNodeHook implements INodeViewLif
 			node.setSide(MapController.suggestNewChildSide(targetNode, asSibling ? Side.AS_SIBLING : Side.DEFAULT));
 			mapController.insertNode(node, targetNode, asSibling);
 		}
+		setExternalResource(uri, node);
+		return true;
+	}
+
+	public void setExternalResource(URI uri, NodeModel node) {
 		final ExternalResource preview = new ExternalResource(uri);
 		undoableDeactivateHook(node);
 		undoableActivateHook(node, preview);
+		File file = new File(uri.getPath());
 		ProgressIcons.updateExtendedProgressIcons(node, file.getName());
-		return true;
-    }
+	}
 
 	public IViewerFactory getViewerFactory() {
 	    return combiFactory;

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/ExternalObjectProxy.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/ExternalObjectProxy.java
@@ -100,7 +100,7 @@ class ExternalObjectProxy extends AbstractProxy<NodeModel> implements Proxy.Exte
 
     private void setUriImpl(final URI uri) {
         if (uri != null)
-            getViewerController().pasteImage(uri, getDelegate());
+            getViewerController().setExternalResource(uri, getDelegate());
     }
 
     @Deprecated


### PR DESCRIPTION
After running more tests, I found a bug. It caused Pack And Go-Go to stop working when OptionPanel.links == "relative". I realized that a different approach was needed to make it work, therefore my original changes for pasteImage, from PR #1382, are no longer required and can be reverted.

I think that for scripting purposes, it's best to allow User to decide what URI they want to set for externalObject – be it absolute or relative, therefore I extracted a method to be used for this purpose.
Also, this is a requirement for Pack And Go-Go to work correctly.