### PR TITLE
CI: Test on Java 21 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        java-version: ['17', '18']
+        java-version: ['17', '21']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'


### PR DESCRIPTION
Modify the GitHub Actions build matrix to test on Java 21 LTS instead of the now unsupported Java 18.