### PR TITLE
Create GitHub Action CI workflow to keep Gradle Wrapper up-to-date

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,15 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1


### PR DESCRIPTION
This action keeps the Gradle Wrapper script up-to-date to the latest release.

It schedules an automatic weekly workflow: as soon as a new Gradle release is available, the action will open a PR ready to be merged.

See https://github.com/gradle-update/update-gradle-wrapper-action.