### PR TITLE
adds mindMap.getStyleNodes method to API

### DIFF
--- a/freeplane_api/src/main/java/org/freeplane/api/MindMapRO.java
+++ b/freeplane_api/src/main/java/org/freeplane/api/MindMapRO.java
@@ -2,6 +2,7 @@ package org.freeplane.api;
 
 import java.awt.Color;
 import java.io.File;
+import java.util.List;
 
 /** The map a node belongs to: <code>node.map</code> - read-only. 
  * 
@@ -38,4 +39,13 @@ public interface MindMapRO {
 
 	/** @since 1.11.1 */
 	ConditionalStyles getConditionalStyles();
+
+	/** returns a list with the nodes of the specified group from the styleMap
+	 *
+	 * @param group StyleGroup.PREDEFINED, USER_DEFINED or AUTOMATIC_LAYOUT
+	 * @since 1.11.8
+	 * @return list of nodes
+	 */
+	List<? extends Node> getStyleNodes(StyleGroup group);
+
 }

--- a/freeplane_api/src/main/java/org/freeplane/api/MindMapRO.java
+++ b/freeplane_api/src/main/java/org/freeplane/api/MindMapRO.java
@@ -42,6 +42,17 @@ public interface MindMapRO {
 
 	/** returns a list with the nodes of the specified group from the styleMap
 	 *
+	 * <b>Example:</b>
+	 * <pre>
+	 * import org.freeplane.api.StyleGroup
+	 *
+	 * def map = node.mindMap
+	 *
+	 * println "Predefined styles       : ${ map.getStyleNodes( StyleGroup.PREDEFINED       ) } \n"
+	 * println "User defined styles     : ${ map.getStyleNodes( StyleGroup.USER_DEFINED     ) } \n"
+	 * println "Automatic layout styles : ${ map.getStyleNodes( StyleGroup.AUTOMATIC_LAYOUT ) } \n"
+	 * </pre>
+	 *
 	 * @param group StyleGroup.PREDEFINED, USER_DEFINED or AUTOMATIC_LAYOUT
 	 * @since 1.11.8
 	 * @return list of nodes

--- a/freeplane_api/src/main/java/org/freeplane/api/StyleGroup.java
+++ b/freeplane_api/src/main/java/org/freeplane/api/StyleGroup.java
@@ -1,0 +1,7 @@
+package org.freeplane.api;
+
+public enum StyleGroup {
+    PREDEFINED,
+    USER_DEFINED,
+    AUTOMATIC_LAYOUT;
+}

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/MapProxy.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/MapProxy.java
@@ -118,10 +118,10 @@ public class MapProxy extends AbstractProxy<MapModel> implements MindMap, Map {
 				styleGroup = MapStyleModel.STYLES_AUTOMATIC_LAYOUT;
 				break;
 		}
-		return styleGroup!=""? getStyleNodes(styleGroup):null;
+		return styleGroup!=""? getStyleGroupNodes(styleGroup):null;
 	}
 
-	private List<? extends org.freeplane.api.Node> getStyleNodes(String styleGroup) {
+	private List<? extends org.freeplane.api.Node> getStyleGroupNodes(String styleGroup) {
 		MapStyleModel styleModel = MapStyleModel.getExtension(getDelegate());
 		MapModel styleMap = styleModel.getStyleMap();
 		NodeModel styleNodeGroup = styleModel.getStyleNodeGroup(styleMap, styleGroup);

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/MapProxy.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/MapProxy.java
@@ -4,6 +4,7 @@ import groovy.lang.Closure;
 import org.freeplane.api.ConditionalStyles;
 import org.freeplane.api.NodeChangeListener;
 import org.freeplane.api.NodeCondition;
+import org.freeplane.api.StyleGroup;
 import org.freeplane.core.resources.ResourceController;
 import org.freeplane.core.util.ColorUtils;
 import org.freeplane.features.filter.Filter;
@@ -101,6 +102,31 @@ public class MapProxy extends AbstractProxy<MapModel> implements MindMap, Map {
 	@Override
 	public ConditionalStyles getConditionalStyles() {
 		return new MapConditionalStylesProxy(getDelegate(), getScriptContext());
+	}
+
+	@Override
+	public List<? extends org.freeplane.api.Node> getStyleNodes(StyleGroup group) {
+		String styleGroup = "";
+		switch(group){
+			case PREDEFINED:
+				styleGroup = MapStyleModel.STYLES_PREDEFINED;
+				break;
+			case USER_DEFINED:
+				styleGroup = MapStyleModel.STYLES_USER_DEFINED;
+				break;
+			case AUTOMATIC_LAYOUT:
+				styleGroup = MapStyleModel.STYLES_AUTOMATIC_LAYOUT;
+				break;
+		}
+		return styleGroup!=""? getStyleNodes(styleGroup):null;
+	}
+
+	private List<? extends org.freeplane.api.Node> getStyleNodes(String styleGroup) {
+		MapStyleModel styleModel = MapStyleModel.getExtension(getDelegate());
+		MapModel styleMap = styleModel.getStyleMap();
+		NodeModel styleNodeGroup = styleModel.getStyleNodeGroup(styleMap, styleGroup);
+		NodeProxy styleGroupParentNode = new NodeProxy(styleNodeGroup, getScriptContext());
+		return styleGroupParentNode.getChildren();
 	}
 
 	// Map: R/W


### PR DESCRIPTION
This PR adds a method to the mindMap API to get access to the styleNodes in the styleMap.

script example :
```groovy
import org.freeplane.api.StyleGroup

def map = node.mindMap

println "Predefined styles       : ${ map.getStyleNodes( StyleGroup.PREDEFINED       ) } \n"
println "User defined styles     : ${ map.getStyleNodes( StyleGroup.USER_DEFINED     ) } \n"
println "Automatic layout styles : ${ map.getStyleNodes( StyleGroup.AUTOMATIC_LAYOUT ) } \n"

```

outputs :
```
Predefined styles       : [(Node) Default, (Node) Details, (Node) Attributes, (Node) Note, (Node) Floating node, (Node) Selected node] 

User defined styles     : [(Node) Important] 

Automatic layout styles : [(Node) Root, (Node) Level 1, (Node) Level 2, (Node) Level 3, (Node) Level 4, (Node) Level 5, (Node) Level 6, (Node) Level 7, (Node) Level 8, (Node) Level 9, (Node) Level 10] 


```