### PR TITLE
adds mindMap.getUserDefinedStylesNames()

### DIFF
--- a/freeplane_api/src/main/java/org/freeplane/api/MindMapRO.java
+++ b/freeplane_api/src/main/java/org/freeplane/api/MindMapRO.java
@@ -2,6 +2,7 @@ package org.freeplane.api;
 
 import java.awt.Color;
 import java.io.File;
+import java.util.List;
 
 /** The map a node belongs to: <code>node.map</code> - read-only. 
  * 
@@ -38,4 +39,11 @@ public interface MindMapRO {
 
 	/** @since 1.11.1 */
 	ConditionalStyles getConditionalStyles();
+
+	/** returns list with the user defined styles names of the map
+	 * @since 1.11.8
+	 * @return list of String
+	 */
+	List<String> getUserDefinedStylesNames();
+
 }

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/MapProxy.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/MapProxy.java
@@ -29,6 +29,8 @@ import org.freeplane.plugin.script.proxy.Proxy.Node;
 
 import java.awt.*;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -101,6 +103,23 @@ public class MapProxy extends AbstractProxy<MapModel> implements MindMap, Map {
 	@Override
 	public ConditionalStyles getConditionalStyles() {
 		return new MapConditionalStylesProxy(getDelegate(), getScriptContext());
+	}
+
+	@Override
+	public List<String> getUserDefinedStylesNames() {
+		final MapStyleModel styleModel = MapStyleModel.getExtension(getDelegate());
+		final MapModel styleMap = styleModel.getStyleMap();
+		final NodeModel styleNodeGroup = styleModel.getStyleNodeGroup(styleMap, MapStyleModel.STYLES_USER_DEFINED);
+		final List<NodeModel> nodes = styleNodeGroup.getChildren();
+		int size = nodes.size();
+		if (size == 0) {
+			return Collections.emptyList();
+		}
+		final ArrayList<String> list = new ArrayList<String>(size);
+		for (final NodeModel node : nodes) {
+			list.add(node.getText());
+		}
+		return Collections.unmodifiableList(list);
 	}
 
 	// Map: R/W


### PR DESCRIPTION
creates a new api method to get the list of the user defined style names from the mind map.

example use case in one of my mind maps:
```groovy
return node.mindMap.userDefinedStylesNames
```

returns:
```
['Important', 'GroovyNode', 'hasGroovyNode', 'baseFolder', 'newFolderImport', 'freshNew', 'movedRenamed', 'file', 'file_folder', 'missing', 'modifiedFile', 'locked', 'file_folder_with_icon', 'notMovedRenamed', 'nextTask', 'pendingTask', 'maybeTask', 'completedTask', 'discardedTask', 'containsNextTasks', 'containsPendingTasks', 'project', 'tasksBucket', 'milestone']
```

