### PR TITLE
when copying styles between maps, it should copy icons and attributes too

### DIFF
--- a/freeplane/src/main/java/org/freeplane/features/styles/MapStyleModel.java
+++ b/freeplane/src/main/java/org/freeplane/features/styles/MapStyleModel.java
@@ -44,11 +44,13 @@ import org.freeplane.core.util.ColorUtils;
 import org.freeplane.core.util.LogUtils;
 import org.freeplane.features.attribute.AttributeRegistry;
 import org.freeplane.features.attribute.FontSizeExtension;
+import org.freeplane.features.attribute.mindmapmode.MAttributeController;
 import org.freeplane.features.cloud.CloudModel;
 import org.freeplane.features.cloud.CloudShape;
 import org.freeplane.features.edge.EdgeColorsConfigurationFactory;
 import org.freeplane.features.edge.EdgeModel;
 import org.freeplane.features.edge.EdgeStyle;
+import org.freeplane.features.icon.mindmapmode.MIconController;
 import org.freeplane.features.link.ConnectorModel;
 import org.freeplane.features.link.LinkController;
 import org.freeplane.features.link.NodeLinks;
@@ -527,7 +529,9 @@ public class MapStyleModel implements IExtension {
         } else {
             modeController.removeExtensions(LogicalStyleKeys.NODE_STYLE, targetStyleNode, targetStyleNode);
         }
-        modeController.copyExtensions(LogicalStyleKeys.NODE_STYLE, copiedStyleNode, targetStyleNode);
+		modeController.copyExtensions(LogicalStyleKeys.NODE_STYLE, copiedStyleNode, targetStyleNode); //copy Style
+		modeController.copyExtensions(MIconController.Keys.ICONS, copiedStyleNode, targetStyleNode);  //copy Icons
+		MAttributeController.getController().copyAttributesToNode(copiedStyleNode, targetStyleNode);  //copy Attributes
     }
 
 }


### PR DESCRIPTION
Hi,
I think icons and attributes should be considered part of a Style and that´s why they should be copied when copying the style from one mindmap to another.

Best regards,

edo

-----

Added:
- copy icons
- copy attributes

