### PR TITLE
new api method: mindMap.copyUserStylesFrom(...)

### DIFF
--- a/freeplane_api/src/main/java/org/freeplane/api/MindMap.java
+++ b/freeplane_api/src/main/java/org/freeplane/api/MindMap.java
@@ -142,19 +142,15 @@ public interface MindMap extends MindMapRO {
 	
     /**
      * 
-     * Returns all style names/translation keys active for the node.
-     * 
-     * @see getName()
-     * 
+     * Copies a style from another mind map into this mind map.
+     *
      * @since 1.9.8
      */
 	void copyStyleFrom(MindMap source, String styleName);
 
     /**
-     * 
-     * Returns all style names/translation keys active for the node.
-     * 
-     * @see getName()
+     *
+     * Copies a style and its conditional style rules from another mind map into this mind map.
      * 
      * @since 1.9.8
      */

--- a/freeplane_api/src/main/java/org/freeplane/api/MindMap.java
+++ b/freeplane_api/src/main/java/org/freeplane/api/MindMap.java
@@ -2,6 +2,7 @@ package org.freeplane.api;
 
 import java.awt.Color;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -155,4 +156,85 @@ public interface MindMap extends MindMapRO {
      * @since 1.9.8
      */
     void copyConditionalStylesFrom(MindMap source, String styleName);
+
+    /**
+     *
+     * Copies one or more user styles from another mind map into this one.
+     *
+     * @param source mind map containing the desired style(s)
+     * @param includeConditionalRules whether to include conditional style rules or not.
+     * @param styleNameFilters one or more strings to indicate which styles should be copied (REGEX match)
+     * @return list with the names of the copied styles
+     * @since 1.11.9
+     */
+    List<String> copyUserStylesFrom(MindMap source, boolean includeConditionalRules, String... styleNameFilters);
+
+    /**
+     *
+     * Copies one or more user styles from another mind map into this one.
+     *
+     * @param source mind map containing the desired style(s)
+     * @param includeConditionalRules whether to include conditional style rules or not.
+     * @param styleNameFilters ArrayList of strings to indicate which styles should be copied (REGEX match)
+     * @return list with the names of the copied styles
+     * @see #copyUserStylesFrom(MindMap, boolean, String...)
+     * @since 1.11.9
+     */
+    List<String> copyUserStylesFrom(MindMap source, boolean includeConditionalRules, ArrayList<String> styleNameFilters);
+
+    /**
+     *
+     * Copies all user styles and their conditional style rules from another mind map into this one.
+     * <p>
+     * <b>Note:</b> equivalent to: {@code     copyUserStylesFrom(source, true, ".*")}
+     *
+     * @param source mind map containing the desired style(s)
+     * @return list with the names of the copied styles
+     * @see #copyUserStylesFrom(MindMap, boolean, String...)
+     * @since 1.11.9
+     */
+    List<String> copyUserStylesFrom(MindMap source);
+
+    /**
+     *
+     * Copies one or more user styles and their conditional style rules from another mind map into this one.
+     * <p>
+     * <b>Note:</b> equivalent to: {@code     copyUserStylesFrom(source, true, styleNameFilters)}
+     *
+     * @param source mind map containing the desired style(s)
+     * @param styleNameFilters one or more strings to indicate which styles should be copied (REGEX match)
+     * @return list with the names of the copied styles
+     * @see #copyUserStylesFrom(MindMap, boolean, String...)
+     * @since 1.11.9
+     */
+    List<String> copyUserStylesFrom(MindMap source, String... styleNameFilters);
+
+    /**
+     *
+     * Copies one or more user styles and their conditional style rules from another mind map into this one.
+     * <p>
+     * <b>Note:</b> equivalent to: {@code     copyUserStylesFrom(source, true, styleNameFilters)}
+     *
+     * @param source mind map containing the desired style(s)
+     * @param styleNameFilters ArrayList of strings to indicate which styles should be copied (REGEX match)
+     * @return list with the names of the copied styles
+     * @see #copyUserStylesFrom(MindMap, boolean, String...)
+     * @since 1.11.9
+     */
+    List<String> copyUserStylesFrom(MindMap source, ArrayList<String> styleNameFilters);
+
+    /**
+     *
+     * Copies all user styles from another mind map into this one.
+     * <p>
+     * <b>Note:</b> equivalent to: {@code    copyUserStylesFrom(source, includeConditionalRules, ".*")}
+     *
+     *
+     * @param source mind map containing the desired style(s)
+     * @param includeConditionalRules whether to include conditional style rules or not.
+     * @return list with the names of the copied styles
+     * @see #copyUserStylesFrom(MindMap, boolean, String...)
+     * @since 1.11.9
+     */
+    List<String> copyUserStylesFrom(MindMap source, boolean includeConditionalRules);
 }

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/MapProxy.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/MapProxy.java
@@ -105,6 +105,7 @@ public class MapProxy extends AbstractProxy<MapModel> implements MindMap, Map {
 		return new MapConditionalStylesProxy(getDelegate(), getScriptContext());
 	}
 
+    // MapRO: R
 	@Override
 	public List<String> getUserDefinedStylesNames() {
 		final MapStyleModel styleModel = MapStyleModel.getExtension(getDelegate());
@@ -360,4 +361,49 @@ public class MapProxy extends AbstractProxy<MapModel> implements MindMap, Map {
         }
         controller.refreshMapLaterUndoable(getDelegate());
     }
+
+    @Override
+    public List<String> copyUserStylesFrom(org.freeplane.api.MindMap source, boolean includeConditionalRules, String... styleNameFilters) {
+        List<String> styleNames = source.getUserDefinedStylesNames();
+        ArrayList<String> styleNamesToImport = new ArrayList<>();
+        for(String name: styleNames) {
+            for (String filter : styleNameFilters){
+                if(name.matches(filter)) {
+                    styleNamesToImport.add(name);
+                    copyStyleFrom(source, name);
+                    if(includeConditionalRules){
+                        copyConditionalStylesFrom(source, name);
+                    }
+                    break;
+                }
+            }
+        }
+        return styleNamesToImport;
+    }
+
+    @Override
+    public List<String> copyUserStylesFrom(org.freeplane.api.MindMap source, boolean includeConditionalRules, ArrayList<String> styleNameFilters) {
+        return copyUserStylesFrom( source, includeConditionalRules, styleNameFilters.toArray(new String[0]));
+    }
+
+    @Override
+    public List<String> copyUserStylesFrom(org.freeplane.api.MindMap source) {
+        return copyUserStylesFrom( source, true);
+    }
+
+    @Override
+    public List<String> copyUserStylesFrom(org.freeplane.api.MindMap source, String... styleNameFilters) {
+        return copyUserStylesFrom( source, true, styleNameFilters);
+    }
+
+    @Override
+    public List<String> copyUserStylesFrom(org.freeplane.api.MindMap source, ArrayList<String> styleNameFilters) {
+        return copyUserStylesFrom( source, styleNameFilters.toArray(new String[0]));
+    }
+
+    @Override
+    public List<String> copyUserStylesFrom(org.freeplane.api.MindMap source, boolean includeConditionalRules) {
+        return copyUserStylesFrom( source, includeConditionalRules, ".*");
+    }
+
 }


### PR DESCRIPTION
Hi Dimitry,
(Please, there is no rush. I had time this weekend and wanted to take advantage of it. Check it out when you can.)

This PR adds a new API method that allows to copy styles from another mind map.

It's kind of a wrapper for the existing API methods: copyStyleFrom() and copyConditionalStyleFrom()

Characteristics:
- It only works for User defined styles
- It allows to copy multiple styles at once.
it has an optional filter parameter that:
    - if not included --> copies all the user styles
    - if a String (or multiple Strings) --> uses regex match to filter which styles should be copied
- it has a boolean parameter to define if it has to include conditional styles rules or not


I use this to import the styles from a template. Mostly related to an addon functionality.
I had this as a library in the most of my addons, so I think it could be useful for others too and decided to include it in Freeplane's API.

Hope it helps.

BR

edo
    