### PR TITLE
adds System's user.country to defaultLocale

### DIFF
--- a/freeplane/src/main/java/org/freeplane/main/application/ApplicationResourceController.java
+++ b/freeplane/src/main/java/org/freeplane/main/application/ApplicationResourceController.java
@@ -131,7 +131,8 @@ public class ApplicationResourceController extends ResourceController {
 		}
 		resourceLoaders = new LinkedHashSet<>();
 		String country = (String) System.getProperties().get("user.country");
-		setDefaultLocale(props.getProperty(ResourceBundles.RESOURCE_LANGUAGE) + "_" + country);
+		country = country.length()>0?"_" + country:"";
+		setDefaultLocale(props.getProperty(ResourceBundles.RESOURCE_LANGUAGE) + country);
 		autoPropertiesFile = getUserPreferencesFile();
 		addPropertyChangeListener(new IFreeplanePropertyListener() {
 			@Override

--- a/freeplane/src/main/java/org/freeplane/main/application/ApplicationResourceController.java
+++ b/freeplane/src/main/java/org/freeplane/main/application/ApplicationResourceController.java
@@ -130,7 +130,8 @@ public class ApplicationResourceController extends ResourceController {
 			}
 		}
 		resourceLoaders = new LinkedHashSet<>();
-		setDefaultLocale(props.getProperty(ResourceBundles.RESOURCE_LANGUAGE));
+		String country = (String) System.getProperties().get("user.country");
+		setDefaultLocale(props.getProperty(ResourceBundles.RESOURCE_LANGUAGE) + "_" + country);
 		autoPropertiesFile = getUserPreferencesFile();
 		addPropertyChangeListener(new IFreeplanePropertyListener() {
 			@Override


### PR DESCRIPTION
Related to topic #1687

This change makes that the firstDayOfWeek in the Calendar panels is set to Sunday or Monday depending on the user's country.

For example, in my case ( System variable `user.country = CL` )

![image](https://github.com/freeplane/freeplane/assets/35700575/59dfb976-e588-4466-ba19-bfb72a4e2711)
