### PR TITLE
freeplane_debughelper: update openstreetmap repo url

### DIFF
--- a/freeplane_debughelper/build.gradle
+++ b/freeplane_debughelper/build.gradle
@@ -1,7 +1,7 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 repositories {
-    maven { url "https://josm.openstreetmap.de/nexus/content/groups/public/" }
+    maven { url "https://josm.openstreetmap.de/repository/releases/" }
     maven { url "https://repo.spring.io/plugins-release/"}
 }
 


### PR DESCRIPTION
Current repository doesn't seem to exist, so gradle keeps trying to fetch jmapviewer from spring repos, which require authentication:

```bash
FAILURE: Build failed with an exception.

* Where:
Initialization script '/nix/store/wdw15x3256w3gv7jkjmaz211q3344xvc-init-deps.gradle' line: 5

* What went wrong:
Execution failed for task ':freeplane_debughelper:nixDownloadDeps'.
> Could not resolve all files for configuration ':freeplane_debughelper:runtimeClasspath'.
   > Could not find org.openstreetmap.jmapviewer:jmapviewer:2.24.
     Searched in the following locations:
       - https://josm.openstreetmap.de/nexus/content/repositories/releases/org/openstreetmap/jmapviewer/jmapviewer/2.24/jmapviewer-2.24.pom
       - https://repo.osgeo.org/repository/release/org/openstreetmap/jmapviewer/jmapviewer/2.24/jmapviewer-2.24.pom
     Required by:
         project :freeplane_debughelper > project :freeplane_plugin_openmaps

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.14/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 42s
17 actionable tasks: 17 executed
```

Let me know if I should also remove the spring repo, since I don't think it's needed.