### PR TITLE
Javadoc improvement org.freeplane.plugin.script.FreeplaneScriptBaseClass

### DIFF
--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/FreeplaneScriptBaseClass.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/FreeplaneScriptBaseClass.java
@@ -45,22 +45,30 @@ import groovy.lang.Script;
  * Only documented methods are meant to be used in scripts.
  * <p>The following global objects are provided as shortcuts by the binding of this class:
  * <ul>
- * <li><b>ui:</b> see {@link UITools}</li>
+ * <li><b>ui:</b> see {@link org.freeplane.core.ui.components.UITools UITools}</li>
  * <li><b>logger:</b> see {@link LogUtils}</li>
- * <li><b>htmlUtils:</b> see {@link HtmlUtils}</li>
- * <li><b>textUtils:</b> see {@link TextUtils}</li>
- * <li><b>menuUtils:</b> see {@link MenuUtils}</li>
+ * <li><b>htmlUtils:</b> see {@link org.freeplane.core.util.HtmlUtils HtmlUtils}</li>
+ * <li><b>textUtils:</b> see {@link org.freeplane.core.util.TextUtils TextUtils}</li>
+ * <li><b>menuUtils:</b> see {@link org.freeplane.core.util.MenuUtils MenuUtils}</li>
  * <li><b>config:</b> see {@link ConfigProperties}</li>
  * </ul>
  * The following classes may also be useful in scripting:
  * <ul>
- * <li>{@link FreeplaneVersion}</li>
+ * <li>{@link org.freeplane.core.util.FreeplaneVersion FreeplaneVersion}</li>
  * </ul>
  */
 public abstract class FreeplaneScriptBaseClass extends Script {
 	/**
-	 * Accessor for Freeplane's configuration: In scripts available
-	 * as "global variable" <code>config</code>.
+	 * <p>Accessor for Freeplane's configuration: In scripts available as "global variable" {@code config}</p>
+     *
+     * <p>In utility scripts and addon classes "global variable" {@code config} is not available and can be accessed as
+     * in the following example:</p>
+     * <pre>
+     * import org.freeplane.plugin.script.FreeplaneScriptBaseClass.ConfigProperties
+     *
+     * def config = new ConfigProperties()
+     * def installationDir = config.installationBaseDir
+     * </pre>
 	 */
 	public static class ConfigProperties {
 	    private final ResourceController resourceController = ResourceController.getResourceController();

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/FreeplaneScriptBaseClass.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/FreeplaneScriptBaseClass.java
@@ -61,8 +61,8 @@ public abstract class FreeplaneScriptBaseClass extends Script {
 	/**
 	 * <p>Accessor for Freeplane's configuration: In scripts available as "global variable" {@code config}</p>
      *
-     * <p>In utility scripts and addon classes "global variable" {@code config} is not available and can be accessed as
-     * in the following example:</p>
+     * <p>When compiling classes outside of Freeplane, e.g. for add-on development, "global variable" {@code config} is
+     * not available and can be accessed by instantiating ConfigProperties as in the following example:</p>
      * <pre>
      * import org.freeplane.plugin.script.FreeplaneScriptBaseClass.ConfigProperties
      *

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/FreeplaneScriptBaseClass.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/FreeplaneScriptBaseClass.java
@@ -52,6 +52,11 @@ import groovy.lang.Script;
  * <li><b>menuUtils:</b> see {@link org.freeplane.core.util.MenuUtils MenuUtils}</li>
  * <li><b>config:</b> see {@link ConfigProperties}</li>
  * </ul>
+ * <p>In case you compile groovy source code for packaging it as a jar with a Freeplane add-on, these global objects
+ * are not available. To make them available, add the following import to your source code:</p>
+ * <pre>
+ * import static org.freeplane.plugin.script.GroovyStaticImports.*
+ * </pre>
  * The following classes may also be useful in scripting:
  * <ul>
  * <li>{@link org.freeplane.core.util.FreeplaneVersion FreeplaneVersion}</li>
@@ -60,14 +65,10 @@ import groovy.lang.Script;
 public abstract class FreeplaneScriptBaseClass extends Script {
 	/**
 	 * <p>Accessor for Freeplane's configuration: In scripts available as "global variable" {@code config}</p>
-     *
-     * <p>When compiling classes outside of Freeplane, e.g. for add-on development, "global variable" {@code config} is
-     * not available and can be accessed by instantiating ConfigProperties as in the following example:</p>
+     * <p>In case you compile groovy source code for packaging it as a jar with a Freeplane add-on, global variable
+     * {@code config} is not available. To make it available, add the following import:</p>
      * <pre>
-     * import org.freeplane.plugin.script.FreeplaneScriptBaseClass.ConfigProperties
-     *
-     * def config = new ConfigProperties()
-     * def installationDir = config.installationBaseDir
+     * import static org.freeplane.plugin.script.GroovyStaticImports.*
      * </pre>
 	 */
 	public static class ConfigProperties {


### PR DESCRIPTION
Fixed broken links in main description
In main description and ConfigProperties description: added reference to importing GroovyStaticImports in case of compiling source code outside Freeplane, see also https://github.com/freeplane/freeplane/issues/2499
