### PR TITLE
Reduce removal warnings

### DIFF
--- a/JOrtho_0.4_freeplane/src/main/java/SampleApplet.java
+++ b/JOrtho_0.4_freeplane/src/main/java/SampleApplet.java
@@ -26,6 +26,7 @@ import javax.swing.JTextPane;
 
 import com.inet.jortho.SpellChecker;
 
+@SuppressWarnings("removal")
 public class SampleApplet extends JApplet {
 	/**
 	 * 

--- a/freeplane/src/main/java/org/freeplane/core/ui/svgicons/FreeplaneIconFactory.java
+++ b/freeplane/src/main/java/org/freeplane/core/ui/svgicons/FreeplaneIconFactory.java
@@ -12,6 +12,7 @@ import javax.swing.ImageIcon;
 import org.freeplane.core.resources.ResourceController;
 
 /** utility methods to access Freeplane's (builtin and user) icons. */
+@SuppressWarnings("removal")
 public class FreeplaneIconFactory {
 	private static final String ANTIALIAS_SVG = "antialias_svg";
 

--- a/freeplane/src/main/java/org/freeplane/features/filter/condition/ASelectableCondition.java
+++ b/freeplane/src/main/java/org/freeplane/features/filter/condition/ASelectableCondition.java
@@ -23,6 +23,7 @@ import org.freeplane.features.filter.condition.ConditionFactory.ConditionOption;
 import org.freeplane.n3.nanoxml.XMLElement;
 
 
+@SuppressWarnings("removal")
 public abstract class ASelectableCondition  implements ICondition{
 	public static final float STRING_MIN_MATCH_PROB = 0.7F;
 	transient private String description;

--- a/freeplane/src/main/java/org/freeplane/features/link/icons/LinkDecorationConfig.java
+++ b/freeplane/src/main/java/org/freeplane/features/link/icons/LinkDecorationConfig.java
@@ -22,6 +22,7 @@ import org.freeplane.core.util.LogUtils;
  * 
  * @author Stuart Robertson <stuartro@gmail.com>
  */
+@SuppressWarnings("removal")
 class LinkDecorationConfig {
 	private static final int MODIFICATION_CHECK_INTERVAL = 10*1000;
 

--- a/freeplane/src/main/java/org/freeplane/features/map/NodeModel.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/NodeModel.java
@@ -51,6 +51,7 @@ import org.freeplane.features.ui.INodeViewVisitor;
  * Extension methods that add functionality to nodes are in the extension packages
  * and get NodeModel as an argument.
  */
+@SuppressWarnings("removal")
 public class NodeModel{
 	public enum NodeChangeType {
 		FOLDING, REFRESH

--- a/freeplane/src/main/java/org/freeplane/features/url/UrlManager.java
+++ b/freeplane/src/main/java/org/freeplane/features/url/UrlManager.java
@@ -66,6 +66,7 @@ import org.freeplane.n3.nanoxml.XMLParseException;
 /**
  * @author Dimitry Polivaev
  */
+@SuppressWarnings("removal")
 public class UrlManager implements IExtension {
 	public static final String SMB_SCHEME = "smb";
 	public static final String FREEPLANE_SCHEME = "freeplane";

--- a/freeplane/src/main/java/org/freeplane/features/url/mindmapmode/MFileManager.java
+++ b/freeplane/src/main/java/org/freeplane/features/url/mindmapmode/MFileManager.java
@@ -101,6 +101,7 @@ import org.freeplane.view.swing.features.filepreview.MindMapPreviewWithOptions;
 /**
  * @author Dimitry Polivaev
  */
+@SuppressWarnings("removal")
 public class MFileManager extends UrlManager implements IMapViewChangeListener {
 	public static final String STANDARD_TEMPLATE = "standard_template";
 	private static final String DEFAULT_SAVE_DIR_PROPERTY = "default_save_dir";

--- a/freeplane/src/main/java/org/freeplane/features/url/mindmapmode/MapLoader.java
+++ b/freeplane/src/main/java/org/freeplane/features/url/mindmapmode/MapLoader.java
@@ -32,6 +32,7 @@ import org.freeplane.features.url.mindmapmode.MFileManager.AlternativeFileMode;
 import org.freeplane.n3.nanoxml.XMLException;
 import org.freeplane.n3.nanoxml.XMLParseException;
 
+@SuppressWarnings("removal")
 public class MapLoader{
 
 	private final ModeController modeController;

--- a/freeplane/src/main/java/org/freeplane/main/applet/FreeplaneApplet.java
+++ b/freeplane/src/main/java/org/freeplane/main/applet/FreeplaneApplet.java
@@ -70,6 +70,7 @@ import org.freeplane.view.swing.features.nodehistory.NodeHistory;
 import org.freeplane.view.swing.map.MapViewController;
 import org.freeplane.view.swing.map.ViewLayoutTypeAction;
 
+@SuppressWarnings("removal")
 public class FreeplaneApplet extends JApplet {
 
 	@SuppressWarnings("serial")

--- a/freeplane/src/main/java/org/freeplane/main/application/ApplicationResourceController.java
+++ b/freeplane/src/main/java/org/freeplane/main/application/ApplicationResourceController.java
@@ -51,6 +51,7 @@ import org.freeplane.features.mode.mindmapmode.MModeController;
 /**
  * @author Dimitry Polivaev
  */
+@SuppressWarnings("removal")
 public class ApplicationResourceController extends ResourceController {
     private static final String USE_SYSTEM_LOCALE_PROPERTY = "useSystemLocale";
 

--- a/freeplane/src/main/java/org/freeplane/main/application/LastOpenedList.java
+++ b/freeplane/src/main/java/org/freeplane/main/application/LastOpenedList.java
@@ -77,6 +77,7 @@ import org.freeplane.view.swing.map.NodeView;
  * Maps should be shown in the format:"mode\:key",ie."Mindmap\:/home/joerg/freeplane.mm"
  */
 
+@SuppressWarnings("removal")
 public class LastOpenedList implements IMapViewChangeListener, IMapChangeListener {
     static class RecentFile {
         public RecentFile(String restorable) {

--- a/freeplane/src/main/java/org/freeplane/view/swing/features/filepreview/BitmapViewerComponent.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/features/filepreview/BitmapViewerComponent.java
@@ -60,6 +60,7 @@ import com.thebuzzmedia.imgscalr.Scalr;
  * @author Dimitry Polivaev
  * 22.08.2009
  */
+@SuppressWarnings("removal")
 public class BitmapViewerComponent extends JComponent implements ScalableComponent {
 
 	private static class AsyncScalrService extends AsyncScalr{

--- a/freeplane_plugin_bugreport/src/main/java/org/freeplane/plugin/bugreport/ReportGenerator.java
+++ b/freeplane_plugin_bugreport/src/main/java/org/freeplane/plugin/bugreport/ReportGenerator.java
@@ -34,6 +34,7 @@ import org.freeplane.core.util.logging.ErrorLogButton;
 import org.freeplane.features.mode.Controller;
 import org.freeplane.features.ui.ViewController;
 
+@SuppressWarnings("removal")
 public class ReportGenerator extends StreamHandler {
 	private static final String BUGREPORT_USER_ID = "org.freeplane.plugin.bugreport.userid";
 	private static final String REMOTE_LOG = "RemoteLog";

--- a/freeplane_plugin_script/src/main/java/groovy/runtime/metaclass/groovy/grape/GrapeMetaClass.java
+++ b/freeplane_plugin_script/src/main/java/groovy/runtime/metaclass/groovy/grape/GrapeMetaClass.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
+@SuppressWarnings("removal")
 public class GrapeMetaClass extends DelegatingMetaClass {
 	static final private Collection<String> EXTRA_IGNORED_PACKAGES = Arrays.asList(
 			GrapeMetaClass.class.getPackage().getName(),

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/GenericScript.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/GenericScript.java
@@ -48,6 +48,7 @@ import org.freeplane.plugin.script.proxy.ProxyFactory;
  * Implements scripting via JSR233 implementation for all other languages except
  * Groovy.
  */
+@SuppressWarnings("removal")
 public class GenericScript implements IScript {
     public static final class ScriptSource {
         private final File file;

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/GroovyScript.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/GroovyScript.java
@@ -42,6 +42,7 @@ import groovy.lang.Script;
 /**
  * Special scripting implementation for Groovy.
  */
+@SuppressWarnings("removal")
 public class GroovyScript implements IScript {
     final private Object script;
 

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/GroovyShell.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/GroovyShell.java
@@ -55,6 +55,7 @@ import groovy.lang.Script;
  * @author Paul King
  * @version $Revision$
  */
+@SuppressWarnings("removal")
 class GroovyShell extends GroovyObjectSupport {
     static {
         DefaultGroovyMethods.mixin(Number.class, NodeArithmeticsCategory.class);

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/ScriptClassLoader.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/ScriptClassLoader.java
@@ -17,6 +17,7 @@ import groovy.lang.GroovyClassLoader;
 import org.freeplane.api.Script;
 import org.freeplane.core.util.ClassLoaderFactory;
 
+@SuppressWarnings("removal")
 public final class ScriptClassLoader extends GroovyClassLoader {
 	private static final Permission ALL_PERMISSION = new AllPermission();
 	private ScriptingSecurityManager securityManager = null;

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/LoaderProxy.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/LoaderProxy.java
@@ -13,6 +13,7 @@ import org.freeplane.features.mode.mindmapmode.MModeController;
 import org.freeplane.features.url.mindmapmode.MapLoader;
 import org.freeplane.plugin.script.ScriptContext;
 
+@SuppressWarnings("removal")
 class LoaderProxy implements Proxy.Loader {
 
 	static Proxy.Loader of(ScriptContext scriptContext) {

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/NodeChangeListenerForScript.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/proxy/NodeChangeListenerForScript.java
@@ -10,6 +10,7 @@ import org.freeplane.api.NodeChanged.ChangedElement;
 import org.freeplane.features.map.NodeModel;
 import org.freeplane.plugin.script.ScriptContext;
 
+@SuppressWarnings("removal")
 class NodeChangeListenerForScript {
 	static Predicate<? super NodeChangeListenerForScript> contains(NodeChangeListener listener) {
 		return e -> e.scriptListener.equals(listener);


### PR DESCRIPTION
## Summary
- add `@SuppressWarnings("removal")` to classes using old JDK APIs
- keep build configuration the same

## Testing
- `gradle build --console=plain --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6859c2587a8c832086526fefb0295051