### PR TITLE
Update Resources_en.properties

### DIFF
--- a/freeplane/src/viewer/resources/translations/Resources_en.properties
+++ b/freeplane/src/viewer/resources/translations/Resources_en.properties
@@ -1225,7 +1225,7 @@ OptionPanel.approximate_search_threshold=Threshold for approximate matching
 OptionPanel.approximate_search_threshold.tooltip=<html>Threshold for approximate matching<br/><font size="2">see https://freeplane.sourceforge.io/wiki/index.php/Approximate_search</font><br/>(the higher the fewer variations<br/>of the search term will be found).</html>
 OptionPanel.ar=Arabic / \u0627\u0644\u0639\u0631\u0628\u064A\u0629
 OptionPanel.ask=Ask
-OptionPanel.assignsNodeDependantStylesToNewConnectors=Assigns node dependant styles to new connectors
+OptionPanel.assignsNodeDependantStylesToNewConnectors=Assign node-dependent styles to new connectors
 OptionPanel.attribute_table_width_fits_content=Optimize attribute width
 OptionPanel.auto_compact_layout=Apply compact layout
 OptionPanel.automatic=Automatic
@@ -1683,7 +1683,7 @@ OptionPanel.separator.RichTextEditor=Rich-Text Editor
 OptionPanel.separator.root_node_appearance=Root node appearance
 OptionPanel.separator.save=Save
 OptionPanel.separator.scripting=Scripting
-OptionPanel.separator.scrollling=Scrollling
+OptionPanel.separator.scrollling=Scrolling
 OptionPanel.separator.search=Search
 OptionPanel.separator.selection=Selection
 OptionPanel.separator.selection_colors=Selection colors


### PR DESCRIPTION
Minor corrections for Preferences dialog text

Fixed spelling of "Scrollling" section in Behaviour tab - it had 3 L's instead of 2.

Fixed spelling/grammar for first Connectors option on Defaults tab. New description says "Assign node-dependent styles to new connectors".