### PR TITLE
Import of Freeplane script globals to script classpath

### DIFF
--- a/freeplane/src/viewer/resources/translations/Resources_en.properties
+++ b/freeplane/src/viewer/resources/translations/Resources_en.properties
@@ -2041,6 +2041,7 @@ ScriptEditor.text=Edit script\u2026
 ScriptEditor.tooltip=Enables to write larger scripts within Freeplane.
 ScriptEditorPanel.changed_cancel=The scripts were changed. Do you really want to abandon those changes?
 scripting=Scripts
+scripting_api_generator_classpath=Script Classpath Development
 scripting_api_generator_legend=Legend
 scripting_api_generator_proxy=Proxy
 scripting_api_generator_title=Generate Scripting API map

--- a/freeplane_plugin_script/build.gradle
+++ b/freeplane_plugin_script/build.gradle
@@ -26,6 +26,7 @@ ext.bundleImports = 'de.sciss.syntaxpane.*'
 ext.bundleExports = """\
              org.freeplane.plugin.script,
              org.freeplane.plugin.script.addons,
+             org.freeplane.plugin.script.classpath,
              org.freeplane.plugin.script.dependencies,
              org.freeplane.plugin.script.filter,
              org.freeplane.plugin.script.proxy
@@ -48,7 +49,7 @@ javadoc {
       .include('**/Convertible.java')
       .include('**/FreeplaneScriptBaseClass.java')
       .include('**/ScriptUtils.java')
-      .include('**/GroovyStaticImports.java') +
+      .include('**/ScriptGlobalsImport.java') +
 		fileTree(dir: '../freeplane_api/src/main/java')
 		  .include('**/api/*.java') +
 		fileTree(dir: '../freeplane/src/main/java')

--- a/freeplane_plugin_script/scripts/apiGenerator.groovy
+++ b/freeplane_plugin_script/scripts/apiGenerator.groovy
@@ -58,7 +58,7 @@ import org.freeplane.core.util.LogUtils
 import org.freeplane.core.util.TextUtils
 import org.freeplane.launcher.Launcher
 import org.freeplane.plugin.script.FreeplaneScriptBaseClass
-import org.freeplane.plugin.script.GroovyStaticImports
+import org.freeplane.plugin.script.classpath.ScriptGlobalsImport
 import org.freeplane.plugin.script.proxy.Convertible
 import org.freeplane.plugin.script.proxy.Proxy
 import org.freeplane.plugin.script.proxy.ScriptUtils
@@ -333,6 +333,7 @@ this.freeplaneApiBase = new File(ResourceController.resourceController.installat
 def MAP_NAME = textUtils.getText('scripting_api_generator_title')
 def PROXY_NODE = textUtils.getText('scripting_api_generator_proxy')
 def UTILITES_NODE = textUtils.getText('scripting_api_generator_utilities')
+def CLASSPATH_NODE = textUtils.getText('scripting_api_generator_classpath')
 def WEB_NODE = textUtils.getText('scripting_api_generator_web')
 def LEGEND_NODE = textUtils.getText('scripting_api_generator_legend')
 def ICONS_NODE = textUtils.getText('icons')
@@ -426,7 +427,6 @@ makeApi(utils, UITools.InsertEolAction.class)
 makeApi(utils, JFileChooser.class)
 //org.freeplane.core.util
 makeApi(utils, LogUtils.class)
-makeApi(utils, GroovyStaticImports.class)
 makeApi(utils, HtmlUtils.class)
 makeApi(utils, HtmlUtils.IndexPair.class)
 makeApi(utils, TextUtils.class)
@@ -460,11 +460,11 @@ bundle.getKeys().toList()
         }
 icons.folded = true
 
-def web = createChild(newMap.root, WEB_NODE, 'https://docs.freeplane.org/scripting/Scripting.html')
-initHeading(web)
-createChild(web, 'Groovy - learn', 'https://groovy-lang.org/learn.html')
-createChild(web, 'Groovy - learn X in Y minutes', 'https://learnxinyminutes.com/docs/groovy/')
-createChild(web, 'Example scripts', 'https://docs.freeplane.org/scripting/Scripts_collection.html')
+// Script Classpath Development
+def classpath = newMap.root.createChild(CLASSPATH_NODE)
+initHeading(classpath)
+// org.freeplane.plugin.script.classpath
+makeApi(classpath, ScriptGlobalsImport.class)
 
 def legend = newMap.root.createChild(LEGEND_NODE)
 initHeading(legend)
@@ -488,6 +488,12 @@ def deprecatedLegend = legend.createChild("Deprecated methods have a 'closed' ic
 deprecatedLegend.createChild("Follow the class' link to the detailed API description to find out what to use instead.")
 deprecatedLegend.icons.add('closed')
 deprecatedLegend.folded = true
+
+def web = createChild(newMap.root, WEB_NODE, 'https://docs.freeplane.org/scripting/Scripting.html')
+initHeading(web)
+createChild(web, 'Groovy - learn', 'https://groovy-lang.org/learn.html')
+createChild(web, 'Groovy - learn X in Y minutes', 'https://learnxinyminutes.com/docs/groovy/')
+createChild(web, 'Example scripts', 'https://docs.freeplane.org/scripting/Scripts_collection.html')
 
 c.deactivateUndo()
 newMap.saved = true

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/FreeplaneScriptBaseClass.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/FreeplaneScriptBaseClass.java
@@ -27,10 +27,10 @@ import org.freeplane.core.resources.ResourceController;
 import org.freeplane.core.ui.TimePeriodUnits;
 import org.freeplane.core.util.Hyperlink;
 import org.freeplane.core.util.LogUtils;
-import org.freeplane.features.format.FormatController;
-import org.freeplane.features.format.ScannerController;
+import org.freeplane.features.format.IFormattedObject;
 import org.freeplane.features.link.LinkController;
 import org.freeplane.features.map.NodeModel;
+import org.freeplane.plugin.script.classpath.ScriptGlobalsImport;
 import org.freeplane.plugin.script.proxy.AbstractProxy;
 import org.freeplane.plugin.script.proxy.Convertible;
 import org.freeplane.plugin.script.proxy.ProxyFactory;
@@ -55,7 +55,7 @@ import groovy.lang.Script;
  * <p>In case you compile groovy source code for packaging it as a jar with a Freeplane add-on, these global objects
  * are not available. To make them available, add the following import to your source code:</p>
  * <pre>
- * import static org.freeplane.plugin.script.GroovyStaticImports.*
+ * import static org.freeplane.plugin.script.classpath.GroovyStaticImports.*
  * </pre>
  * The following classes may also be useful in scripting:
  * <ul>
@@ -68,7 +68,7 @@ public abstract class FreeplaneScriptBaseClass extends Script {
      * <p>In case you compile groovy source code for packaging it as a jar with a Freeplane add-on, global variable
      * {@code config} is not available. To make it available, add the following import:</p>
      * <pre>
-     * import static org.freeplane.plugin.script.GroovyStaticImports.*
+     * import static org.freeplane.plugin.script.classpath.GroovyStaticImports.*
      * </pre>
 	 */
 	public static class ConfigProperties {
@@ -388,17 +388,17 @@ public abstract class FreeplaneScriptBaseClass extends Script {
 
 	/** returns valueIfNull if value is null and value otherwise. */
 	public Object ifNull(Object value, Object valueIfNull) {
-		return GroovyStaticImports.ifNull(value, valueIfNull);
+		return ScriptGlobalsImport.ifNull(value, valueIfNull);
 	}
 
 	/** rounds a number to integral type. */
     public Long round(final Double d) {
-    	return GroovyStaticImports.round(d);
+    	return ScriptGlobalsImport.round(d);
     }
 
     /** round to the given number of decimal places: <code>round(0.1234, 2) &rarr; 0.12</code> */
     public Double round(final Double d, final int precision) {
-    	return GroovyStaticImports.round(d, precision);
+    	return ScriptGlobalsImport.round(d, precision);
     }
 
     /** parses text to the proper data type, if possible, setting format to the standard. Parsing is configured via
@@ -413,7 +413,7 @@ public abstract class FreeplaneScriptBaseClass extends Script {
      * c.statusInfo = "${d} is ${new Date() - d} days ago"
      * </pre> */
     public Object parse(final String text) {
-    	return GroovyStaticImports.parse(text);
+    	return ScriptGlobalsImport.parse(text);
     }
 
     /** uses formatString to return a FormattedObject.
@@ -424,26 +424,26 @@ public abstract class FreeplaneScriptBaseClass extends Script {
      * </pre>
      * @return {@link IFormattedObject} if object is formattable and the unchanged object otherwise. */
     public Object format(final Object object, final String formatString) {
-    	return GroovyStaticImports.format(object, formatString);
+    	return ScriptGlobalsImport.format(object, formatString);
     }
 
     /** Applies default date-time format for dates or default number format for numbers. All other objects are left unchanged.
      * @return {@link IFormattedObject} if object is formattable and the unchanged object otherwise. */
     public Object format(final Object object) {
-    	return GroovyStaticImports.format(object);
+    	return ScriptGlobalsImport.format(object);
     }
 
     /** Applies default date format (instead of standard date-time) format on the given date.
      * @return {@link IFormattedObject} if object is formattable and the unchanged object otherwise. */
     public Object formatDate(final Date date) {
-        return GroovyStaticImports.format(date);
+        return ScriptGlobalsImport.format(date);
     }
 
     /** formats according to the internal standard, that is the conversion will be reversible
      * for types that are handled special by the scripting api namely Dates and Numbers.
      * @see Convertible#toString(Object) */
     public String toString(final Object o) {
-        return GroovyStaticImports.toString(o);
+        return ScriptGlobalsImport.toString(o);
     }
 
     /** opens a {@link URI} */

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/GroovyScript.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/GroovyScript.java
@@ -25,6 +25,7 @@ import java.security.AccessControlException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Map.Entry;
 import java.util.regex.Matcher;
 
 import org.codehaus.groovy.ast.ASTNode;
@@ -33,11 +34,14 @@ import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.freeplane.features.map.NodeModel;
+import org.freeplane.plugin.script.classpath.ScriptGlobalsImport;
 import org.freeplane.plugin.script.proxy.ScriptUtils;
 
 import groovy.lang.Binding;
 import groovy.lang.GroovyRuntimeException;
 import groovy.lang.Script;
+
+import static org.freeplane.plugin.script.classpath.ScriptGlobalsImport.logger;
 
 /**
  * Special scripting implementation for Groovy.
@@ -203,6 +207,9 @@ public class GroovyScript implements IScript {
     private Binding createBindingForCompilation() {
         final Binding binding = new Binding();
         binding.setVariable("script", script);
+        for (Entry<String, Object> entry : ScriptingConfiguration.getStaticProperties().entrySet()) {
+            binding.setVariable(entry.getKey(), entry.getValue());
+        }
         return binding;
     }
 
@@ -228,7 +235,16 @@ public class GroovyScript implements IScript {
         }
         final ImportCustomizer importCustomizer = new ImportCustomizer();
         importCustomizer.addStaticImport(ScriptUtils.class.getName(), "ignoreCycles");
-        importCustomizer.addStaticStars(GroovyStaticImports.class.getName());
+        /*
+         * TODO: Reapply changes commit a30ddc4c03fbeffcb6adb6403862efd2287e9369 and uncomment next 6 lines to replace
+         * injection of GroovyStaticImports or remove same 6 lines depending on user feedback from preview or v1.12.12
+         */
+//        importCustomizer.addStaticImport(ScriptGlobalsImport.class.getName(), "logger");
+//        importCustomizer.addStaticImport(ScriptGlobalsImport.class.getName(), "ui");
+//        importCustomizer.addStaticImport(ScriptGlobalsImport.class.getName(), "htmlUtils");
+//        importCustomizer.addStaticImport(ScriptGlobalsImport.class.getName(), "textUtils");
+//        importCustomizer.addStaticImport(ScriptGlobalsImport.class.getName(), "menuUtils");
+//        importCustomizer.addStaticImport(ScriptGlobalsImport.class.getName(), "config");
         config.addCompilationCustomizers(importCustomizer);
         return config;
     }

--- a/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/classpath/ScriptGlobalsImport.java
+++ b/freeplane_plugin_script/src/main/java/org/freeplane/plugin/script/classpath/ScriptGlobalsImport.java
@@ -1,41 +1,61 @@
 /*
- * Created on 30 Jan 2024
+ * Created on 30 Jan 2024 as GroovyStaticImports
  *
  * author dimitry
  */
-package org.freeplane.plugin.script;
+package org.freeplane.plugin.script.classpath;
 
 import java.util.Date;
-import java.util.function.Supplier;
+// Enable or remove when ignoreCycles method is enabled or removed
+//import java.util.function.Supplier;
 
+import org.freeplane.api.NodeRO;
 import org.freeplane.core.ui.components.UITools;
 import org.freeplane.core.util.HtmlUtils;
 import org.freeplane.core.util.LogUtils;
 import org.freeplane.core.util.MenuUtils;
 import org.freeplane.core.util.TextUtils;
 import org.freeplane.features.format.FormatController;
+import org.freeplane.features.format.IFormattedObject;
 import org.freeplane.features.format.ScannerController;
+import org.freeplane.plugin.script.ExecuteScriptException;
+import org.freeplane.plugin.script.FreeplaneScriptBaseClass;
 import org.freeplane.plugin.script.proxy.Convertible;
+import org.freeplane.plugin.script.proxy.Proxy;
 import org.freeplane.plugin.script.proxy.ScriptUtils;
 
 /**
- * Provides static imports for Freeplane scripting utilities to enable easy access to common functionality
- * when compiling Groovy source code outside of Freeplane's script environment.
+ * Optionally provides access to Freeplane scripting conventions, like {@code node} and {@code ui}, in {@code
+ * .groovy} files that are stored in the script classpath directories. They are automatically compiled when Freeplane
+ * starts and the resulting classes and their methods are available to scripts, and their methods are available as
+ * functions in formula.
  * 
- * <p>This class is particularly useful when creating utility scripts or add-on classes that need to be
- * compiled as JAR files. In regular Freeplane scripts, these utilities are available as global variables,
- * but when compiling outside Freeplane, you need to import them explicitly.</p>
+ * <p>This class needs to be explicitly imported into a script classpath {@code .groovy} file. It then provides all
+ * global objects, variables and methods that are automatically available to regular Freeplane scripts.</p>
  * 
  * <p><strong>Usage:</strong></p>
  * <pre>
- * import static org.freeplane.plugin.script.GroovyStaticImports.*
+ * import static org.freeplane.plugin.script.classpath.ScriptGlobalsImport.*
  * 
  * // Now you can use:
- * logger.info("Hello from my utility script")
+ * String nodeID = node.id
+ * String nodeText = T(nodID)
  * ui.informationMessage("This is a message")
- * String plainText = htmlUtils.htmlToPlain("&lt;b&gt;Bold text&lt;/b&gt;")
  * </pre>
- * 
+ *
+ * <p>If you only need a few of the global objects, you can make specific imports, for example:</p>
+ *
+ * <pre>
+ * import static org.freeplane.plugin.script.classpath.ScriptGlobalsImport.node
+ * import static org.freeplane.plugin.script.classpath.ScriptGlobalsImport.ui
+ * </pre>
+ *
+ * <p>As an alternative to static import of {@code ScriptGlobalsImport}, you can also import a script utility class
+ * directly.</p>
+ *
+ * <p>Since it is a static import, you can use the methods without prefix, just like in a Freeplane script. In addition
+ * </p>
+ *
  * <p>The following utilities are made available through static imports:</p>
  * <ul>
  * <li>{@link #logger} - for logging messages (see {@link LogUtils})</li>
@@ -43,17 +63,17 @@ import org.freeplane.plugin.script.proxy.ScriptUtils;
  * <li>{@link #htmlUtils} - for HTML/XML processing (see {@link HtmlUtils})</li>
  * <li>{@link #textUtils} - for text processing and translations (see {@link TextUtils})</li>
  * <li>{@link #menuUtils} - for menu operations (see {@link MenuUtils})</li>
- * <li>{@link #scriptUtils} - for script-specific utilities (see {@link ScriptUtils})</li>
- * <li>{@link #config} - for accessing Freeplane configuration (see {@link org.freeplane.plugin.script.FreeplaneScriptBaseClass.ConfigProperties})</li>
+ * <li>{@link #config} - for accessing Freeplane configuration (see {@link FreeplaneScriptBaseClass.ConfigProperties})</li>
  * </ul>
  * 
  * <p>Additionally, this class provides utility methods for common operations like null checking,
- * number rounding, text parsing, and formatting.</p>
+ * number rounding, text parsing, and formatting. You can also use the well-known global variables {@link #c} and
+ * {@link #node}.</p>
  * 
  * @see org.freeplane.plugin.script.FreeplaneScriptBaseClass
  * @since 1.12.x (created on 30 Jan 2024)
  */
-public class GroovyStaticImports {
+public class ScriptGlobalsImport {
     /** 
      * Utilities for logging messages to Freeplane's log file. Use for debugging and error reporting.
      * @see LogUtils
@@ -84,32 +104,61 @@ public class GroovyStaticImports {
      */
     public final static MenuUtils menuUtils = new MenuUtils();
     
-    /** 
-     * Utilities for script-specific operations, particularly useful in utility scripts and add-ons.
-     * @see ScriptUtils
-     */
-    public final static ScriptUtils scriptUtils = new ScriptUtils();
-    
-    /** 
+    /**
      * Accessor for Freeplane's configuration properties. Provides access to all configuration settings.
      * <p>Note: In utility scripts and add-on classes, this static instance is the recommended way to access
      * configuration, as the global {@code config} variable is not available when compiling outside Freeplane.</p>
      */
     public final static FreeplaneScriptBaseClass.ConfigProperties config = new FreeplaneScriptBaseClass.ConfigProperties();
-    
+
     /**
-     * Executes the given closure while ignoring any cyclic dependencies in formulas.
-     * If there are cyclic dependencies, formulas are skipped without warnings or exceptions.
-     * 
-     * @param <T> the return type of the closure
-     * @param closure the operation to execute
-     * @return the result of the closure execution
+     * Makes {@code ScriptUtils.c()} available  as {@code c}
+     * @see ScriptUtils
      */
-    public static <T> T ignoreCycles(final Supplier<T> closure) {
-        return ScriptUtils.ignoreCycles(closure);
+    public final static Proxy.Controller c = ScriptUtils.c();
+
+    /**
+     * Makes {@code ScriptUtils.node()} available as {@code node}
+     * @see ScriptUtils
+     */
+    public final static Proxy.Node node = ScriptUtils.node();
+
+//    /**
+//     * Executes the given closure while ignoring any cyclic dependencies in formulas.
+//     * If there are cyclic dependencies, formulas are skipped without warnings or exceptions.
+//     *
+//     * @param <T> the return type of the closure
+//     * @param closure the operation to execute
+//     * @return the result of the closure execution
+//     */
+//    public static <T> T ignoreCycles(final Supplier<T> closure) {
+//        return ScriptUtils.ignoreCycles(closure);
+//    }
+
+    /** Shortcut for node.map.node(id). */
+    public NodeRO N(String id) {
+        final NodeRO node = ScriptUtils.node();
+        return node.getMindMap().node(id);
     }
 
-	/** returns valueIfNull if value is null and value otherwise. */
+    /** Shortcut for node.map.node(id).text. */
+    public String T(String id) {
+        final NodeRO n = N(id);
+        return n == null ? null : n.getText();
+    }
+
+    /** Shortcut for node.map.node(id).value. */
+    public Object V(String id) {
+        final NodeRO n = N(id);
+        try {
+            return n == null ? null : n.getValue();
+        }
+        catch (ExecuteScriptException e) {
+            return null;
+        }
+    }
+
+    /** returns valueIfNull if value is null and value otherwise. */
 	public static Object ifNull(Object value, Object valueIfNull) {
 		return value == null ? valueIfNull : value;
 	}


### PR DESCRIPTION
Closes #2499

- [x] Move `org.freeplane.plugin.script.GroovyStaticImports` to package `org.freeplane.plugin.script.classpath`
- [x] Rename `GroovyStaticImports` to `ScriptGlobalsImport`
- [x] In `org.freeplane.plugin.script.GroovyScript`:
    - [x] reverse changes in commit a30ddc4c03fbeffcb6adb6403862efd2287e9369 and add the required `import java.util.Map.Entry;`
    - [x] in `createCompilerConfiguration`: add commented out injections via `importCustomizer` for the 6 globals for script utility classes in `ScriptGlobalsImport`
    - [x] in `createCompilerConfiguration`: add TODO for future action depending on user feedback
- [x] In `ScriptGlobalsImport` in `org.freeplane.plugin.script.classpath`:
    - [x] Replace global `scriptUtils` with globals `c` and `node` for `c()` and `node()`
    - [x] Add `N(String id)`, `T(String id)` and `V(String id)` methods to
    - [x] Add `import org.freeplane.features.format.IFormattedObject;` to `ScriptGlobalsImport` for fixing javadoc
    - [x] Comment out `ignoreCycles(closure)`
    - [x] Rewrite introduction
- [x] Add `import org.freeplane.features.format.IFormattedObject;` to `org.freeplane.plugin.script.FreeplaneScriptBaseClass` for fixing javadoc
- [x] Add new main branch "Script classpath development" to mind map generated by apiGenerator.groovy with

Proposal for completing the PR
- [ ] In `ScriptGlobalsImport` in `org.freeplane.plugin.script.classpath`:
    - [ ] Copy code for methods `c()`, `node()` and `ignoreCycles(closure)` from `ScriptUtils`
    - [ ] Remove the import of `ScriptUtils` and any code referring to it
    - [ ] Document `ignoreCycles(closure)` for use in methods that are used as functions in formulas
- [ ] Annotate `ScriptUtils` as `@deprecated` and refer to `ScriptGlobalsImport` as its replacement
- [ ] In `org.freeplane.plugin.script.FreeplaneScriptBaseClass` add method `ignoreCycles(closure)` based on import from `ScriptGlobalsImport`
- [ ] In `createCompilerConfiguration` in `org.freeplane.plugin.script.GroovyScript`:
    - [ ] change injection of `ignoreCycles` from `ScriptUtils` to injection from `ScriptGlobalsImport`
    - [ ] comment out the whole section related to `importCustomizer` including the changed injection