### PR TITLE
Replace DES with AES-256 (again)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,7 @@ gradle-app.setting
 *.backup
 *.temp
 .!*
+
+# Local testing scripts
+test_encryption_quick.sh
+.classpath_cache

--- a/freeplane/src/main/java/org/freeplane/features/encrypt/Aes256Encrypter.java
+++ b/freeplane/src/main/java/org/freeplane/features/encrypt/Aes256Encrypter.java
@@ -1,0 +1,211 @@
+/*
+ *  Freeplane - mind map editor
+ *  Copyright (C) 2025 Freeplane team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.freeplane.features.encrypt;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.util.Arrays;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.freeplane.core.util.LogUtils;
+import org.freeplane.features.map.IEncrypter;
+
+public class Aes256Encrypter implements IEncrypter {
+	private static final int SALT_LENGTH = 16;
+	private static final int IV_LENGTH = 16;
+	private static final int KEY_LENGTH = 256;
+	private static final String KEY_DERIVATION_ALGORITHM = "PBKDF2WithHmacSHA256";
+	private static final String CIPHER_ALGORITHM = "AES/CBC/PKCS5Padding";
+	private static final int ITERATION_COUNT = 100000;
+	
+	private Cipher dcipher;
+	private Cipher ecipher;
+	private byte[] mSalt;
+	private byte[] currentIV;
+	private char[] passPhrase;
+	private final SecureRandom secureRandom;
+
+	public Aes256Encrypter(final StringBuilder pPassPhrase) {
+		passPhrase = new char[pPassPhrase.length()];
+		pPassPhrase.getChars(0, passPhrase.length, passPhrase, 0);
+		secureRandom = new SecureRandom();
+		mSalt = new byte[SALT_LENGTH];
+	}
+
+	@Override
+	public String decrypt(String str) {
+		if (str == null) {
+			return null;
+		}
+		try {
+			String strippedPrefix = EncryptionHeader.stripPrefix(str);
+			if (strippedPrefix == null) {
+				return null;
+			}
+			
+			byte[] allData = DesEncrypter.fromBase64(strippedPrefix);
+			if (allData == null || allData.length < SALT_LENGTH + IV_LENGTH) {
+				return null;
+			}
+			
+			int offset = 0;
+			byte[] salt = Arrays.copyOfRange(allData, offset, offset + SALT_LENGTH);
+			offset += SALT_LENGTH;
+			byte[] iv = Arrays.copyOfRange(allData, offset, offset + IV_LENGTH);
+			offset += IV_LENGTH;
+			
+			if (allData.length <= offset) {
+				return null;
+			}
+			byte[] ciphertext = Arrays.copyOfRange(allData, offset, allData.length);
+			
+			init(salt, iv);
+			if (dcipher == null) {
+				return null;
+			}
+			final byte[] utf8 = dcipher.doFinal(ciphertext);
+			return new String(utf8, StandardCharsets.UTF_8);
+		}
+		catch (final BadPaddingException e) {
+		}
+		catch (final IllegalBlockSizeException e) {
+		}
+		catch (final IllegalArgumentException e) {
+		}
+		return null;
+	}
+
+	@Override
+	public String encrypt(final String str) {
+		try {
+			initWithNewSalt();
+			if (ecipher == null || currentIV == null) {
+				return null;
+			}
+			final byte[] utf8 = str.getBytes(StandardCharsets.UTF_8);
+			final byte[] enc = ecipher.doFinal(utf8);
+			
+			byte[] fullData = new byte[mSalt.length + currentIV.length + enc.length];
+			int offset = 0;
+			System.arraycopy(mSalt, 0, fullData, offset, mSalt.length);
+			offset += mSalt.length;
+			System.arraycopy(currentIV, 0, fullData, offset, currentIV.length);
+			offset += currentIV.length;
+			System.arraycopy(enc, 0, fullData, offset, enc.length);
+			
+		String base64Data = DesEncrypter.toBase64(fullData);
+		return EncryptionHeader.PREFIX_AES256 + base64Data;
+		}
+		catch (final BadPaddingException e) {
+			LogUtils.severe("AES-256 Encryption failed: bad padding", e);
+		}
+		catch (final IllegalBlockSizeException e) {
+			LogUtils.severe("AES-256 Encryption failed: illegal block size", e);
+		}
+		return null;
+	}
+
+	private void initWithNewSalt() {
+		final byte[] newSalt = new byte[SALT_LENGTH];
+		secureRandom.nextBytes(newSalt);
+		init(newSalt, null);
+	}
+
+	private void init(final byte[] salt, final byte[] iv) {
+		if (mSalt != null && salt != null && !Arrays.equals(mSalt, salt)) {
+			ecipher = null;
+			dcipher = null;
+		}
+		if (salt != null) {
+			mSalt = salt;
+		}
+		
+		final boolean needsEncryptionInit = (iv == null && ecipher == null);
+		final boolean needsDecryptionInit = (iv != null && dcipher == null);
+		
+		if (needsEncryptionInit || needsDecryptionInit) {
+			try {
+				final KeySpec keySpec = new PBEKeySpec(passPhrase, mSalt, ITERATION_COUNT, KEY_LENGTH);
+				final SecretKeyFactory factory = SecretKeyFactory.getInstance(KEY_DERIVATION_ALGORITHM);
+				final SecretKey tmpKey = factory.generateSecret(keySpec);
+				final SecretKey key = new SecretKeySpec(tmpKey.getEncoded(), "AES");
+				
+				if (iv == null) {
+					currentIV = new byte[IV_LENGTH];
+					secureRandom.nextBytes(currentIV);
+					final IvParameterSpec ivSpec = new IvParameterSpec(currentIV);
+					ecipher = Cipher.getInstance(CIPHER_ALGORITHM);
+					ecipher.init(Cipher.ENCRYPT_MODE, key, ivSpec);
+				} else {
+					currentIV = iv;
+					final IvParameterSpec ivSpec = new IvParameterSpec(currentIV);
+					dcipher = Cipher.getInstance(CIPHER_ALGORITHM);
+					dcipher.init(Cipher.DECRYPT_MODE, key, ivSpec);
+				}
+			}
+			catch (final InvalidAlgorithmParameterException e) {
+				LogUtils.severe(e);
+			}
+			catch (final InvalidKeySpecException e) {
+				LogUtils.severe(e);
+			}
+			catch (final NoSuchPaddingException e) {
+				LogUtils.severe(e);
+			}
+			catch (final NoSuchAlgorithmException e) {
+				LogUtils.severe(e);
+			}
+			catch (final InvalidKeyException e) {
+				LogUtils.severe(e);
+			}
+		}
+	}
+	
+	@Override
+	public void destroy() {
+		if (passPhrase != null) {
+			Arrays.fill(passPhrase, '\0');
+			passPhrase = null;
+		}
+		if (mSalt != null) {
+			Arrays.fill(mSalt, (byte) 0);
+			mSalt = null;
+		}
+		if (currentIV != null) {
+			Arrays.fill(currentIV, (byte) 0);
+			currentIV = null;
+		}
+		ecipher = null;
+		dcipher = null;
+	}
+}
+

--- a/freeplane/src/main/java/org/freeplane/features/encrypt/DesEncrypter.java
+++ b/freeplane/src/main/java/org/freeplane/features/encrypt/DesEncrypter.java
@@ -21,6 +21,7 @@ package org.freeplane.features.encrypt;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.KeySpec;
 import java.util.Arrays;
@@ -88,13 +89,11 @@ public class DesEncrypter implements IEncrypter {
 				return null;
 			}
 			final byte[] utf8 = dcipher.doFinal(dec);
-			return new String(utf8, "UTF8");
+			return new String(utf8, StandardCharsets.UTF_8);
 		}
 		catch (final javax.crypto.BadPaddingException e) {
 		}
 		catch (final IllegalBlockSizeException e) {
-		}
-		catch (final UnsupportedEncodingException e) {
 		}
 		catch (final IllegalArgumentException e) {
 		}
@@ -106,15 +105,15 @@ public class DesEncrypter implements IEncrypter {
 			initWithNewSalt();
 			if(ecipher == null)
 				return null;
-			final byte[] utf8 = str.getBytes("UTF8");
+			final byte[] utf8 = str.getBytes(StandardCharsets.UTF_8);
 			final byte[] enc = ecipher.doFinal(utf8);
 			return DesEncrypter.toBase64(mSalt) + DesEncrypter.SALT_PRESENT_INDICATOR + DesEncrypter.toBase64(enc);
 		}
 		catch (final javax.crypto.BadPaddingException e) {
+			LogUtils.severe("DES Encryption failed: bad padding", e);
 		}
 		catch (final IllegalBlockSizeException e) {
-		}
-		catch (final UnsupportedEncodingException e) {
+			LogUtils.severe("DES Encryption failed: illegal block size", e);
 		}
 		return null;
 	}
@@ -127,8 +126,6 @@ public class DesEncrypter implements IEncrypter {
 	    init(newSalt);
     }
 
-	/**
-	 */
 	private void init(final byte[] salt) {
 		if (ecipher != null && mSalt != null && !Arrays.equals(mSalt, salt)) {
 			ecipher = null;
@@ -176,5 +173,19 @@ public class DesEncrypter implements IEncrypter {
 				LogUtils.severe(e);
 			}
 		}
+	}
+	
+	@Override
+	public void destroy() {
+		if (passPhrase != null) {
+			Arrays.fill(passPhrase, '\0');
+			passPhrase = null;
+		}
+		if (mSalt != null) {
+			Arrays.fill(mSalt, (byte) 0);
+			mSalt = null;
+		}
+		ecipher = null;
+		dcipher = null;
 	}
 }

--- a/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionController.java
+++ b/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionController.java
@@ -155,7 +155,11 @@ public class EncryptionController implements IExtension {
 
         boolean decrypted = encryptionModel.decrypt(mapController, tempEncrypter);
 
-        if (!decrypted) {
+        if (decrypted) {
+            final IEncrypter aesEncrypter = EncryptionHelper.createEncrypter(password);
+            encryptionModel.setEncrypter(aesEncrypter);
+            tempEncrypter.destroy();
+        } else {
             tempEncrypter.destroy();
         }
 

--- a/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionController.java
+++ b/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionController.java
@@ -29,6 +29,7 @@ import org.freeplane.features.icon.IconStore;
 import org.freeplane.features.icon.UIIcon;
 import org.freeplane.features.icon.factory.IconStoreFactory;
 import org.freeplane.features.map.EncryptionModel;
+import org.freeplane.features.map.IEncrypter;
 import org.freeplane.features.map.MapController;
 import org.freeplane.features.map.MapWriter;
 import org.freeplane.features.map.NodeModel;
@@ -149,7 +150,16 @@ public class EncryptionController implements IExtension {
 
     private boolean decrypt(final EncryptionModel encryptionModel, final StringBuilder password) {
         final MapController mapController = Controller.getCurrentModeController().getMapController();
-        return encryptionModel.decrypt(mapController, new SingleDesEncrypter(password));
+        final String encryptedContent = encryptionModel.getEncryptedContent();
+        final IEncrypter tempEncrypter = EncryptionHelper.createDecrypter(password, encryptedContent);
+
+        boolean decrypted = encryptionModel.decrypt(mapController, tempEncrypter);
+
+        if (!decrypted) {
+            tempEncrypter.destroy();
+        }
+
+        return decrypted;
     }
 
 	private void encrypt(final NodeModel node, PasswordStrategy passwordStrategy) {
@@ -162,7 +172,14 @@ public class EncryptionController implements IExtension {
 		if (passwordStrategy.isCancelled()) {
 			return;
 		}
-		final EncryptionModel encryptionModel = new EncryptionModel(node, new SingleDesEncrypter(password));
+		final IEncrypter encrypter = EncryptionHelper.createEncrypter(password);
+		final EncryptionModel encryptionModel;
+		try {
+			encryptionModel = new EncryptionModel(node, encrypter);
+		} catch (Exception e) {
+			encrypter.destroy();
+			throw e;
+		}
 		final IActor actor = new IActor() {
 			@Override
 			public void act() {

--- a/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionHeader.java
+++ b/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionHeader.java
@@ -1,8 +1,6 @@
 /*
  *  Freeplane - mind map editor
- *  Copyright (C) 2008 Dimitry Polivaev
- *
- *  This file author is Dimitry Polivaev
+ *  Copyright (C) 2025 Freeplane team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -19,12 +17,16 @@
  */
 package org.freeplane.features.encrypt;
 
-/**
- * @author Dimitry Polivaev
- * 29.12.2008
- */
-public class TripleDesEncrypter extends DesEncrypter {
-	public TripleDesEncrypter(final StringBuilder pPassPhrase) {
-		super(pPassPhrase, "PBEWithMD5AndTripleDES");
+public class EncryptionHeader {
+	public static final String PREFIX_AES256 = "FP-AES256-V1:";
+	
+	public static String stripPrefix(String encryptedString) {
+		if (encryptedString == null) {
+			return null;
+		}
+		if (encryptedString.startsWith(PREFIX_AES256)) {
+			return encryptedString.substring(PREFIX_AES256.length());
+		}
+		return null;
 	}
 }

--- a/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionHelper.java
+++ b/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionHelper.java
@@ -1,0 +1,48 @@
+/*
+ *  Freeplane - mind map editor
+ *  Copyright (C) 2025 Freeplane team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.freeplane.features.encrypt;
+
+import org.freeplane.features.map.IEncrypter;
+
+public class EncryptionHelper {
+	
+	public static IEncrypter createEncrypter(final StringBuilder password) {
+		return new Aes256Encrypter(password);
+	}
+	
+	public static IEncrypter createDecrypter(final StringBuilder password, final String encryptedContent) {
+		if (encryptedContent == null) {
+			return new Aes256Encrypter(password);
+		}
+		if (encryptedContent.startsWith(EncryptionHeader.PREFIX_AES256)) {
+			return new Aes256Encrypter(password);
+		}
+		return new SingleDesEncrypter(password);
+	}
+	
+	public static String getEncryptionAlgorithmDescription(final String encryptedContent) {
+		if (encryptedContent == null) {
+			return "Unknown";
+		}
+		if (encryptedContent.startsWith(EncryptionHeader.PREFIX_AES256)) {
+			return "AES-256";
+		}
+		return "DES";
+	}
+	
+}

--- a/freeplane/src/main/java/org/freeplane/features/encrypt/mindmapmode/EncryptedMap.java
+++ b/freeplane/src/main/java/org/freeplane/features/encrypt/mindmapmode/EncryptedMap.java
@@ -23,8 +23,9 @@ import org.freeplane.core.ui.AFreeplaneAction;
 import org.freeplane.core.ui.components.EnterPasswordDialog;
 import org.freeplane.core.ui.components.UITools;
 import org.freeplane.core.ui.menubuilders.generic.UserRole;
-import org.freeplane.features.encrypt.SingleDesEncrypter;
+import org.freeplane.features.encrypt.EncryptionHelper;
 import org.freeplane.features.map.EncryptionModel;
+import org.freeplane.features.map.IEncrypter;
 import org.freeplane.features.map.MapModel;
 import org.freeplane.features.map.NodeModel;
 import org.freeplane.features.mode.Controller;
@@ -33,7 +34,7 @@ import org.freeplane.features.url.mindmapmode.MFileManager;
 
 class EncryptedMap extends AFreeplaneAction {
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
 
@@ -46,7 +47,7 @@ class EncryptedMap extends AFreeplaneAction {
 	}
 
 	/**
-	 * @param e 
+	 * @param e
 	 */
 	private StringBuilder getUsersPassword() {
 		final EnterPasswordDialog pwdDialog = new EnterPasswordDialog(UITools.getCurrentFrame(), true);
@@ -60,7 +61,7 @@ class EncryptedMap extends AFreeplaneAction {
 	}
 
 	/**
-	 * @param e 
+	 * @param e
 	 *
 	 */
 	private void newEncryptedMap() {
@@ -71,13 +72,20 @@ class EncryptedMap extends AFreeplaneAction {
 		final ModeController modeController = Controller.getCurrentModeController();
 		MapModel newMap = MFileManager.getController(modeController).newMapFromDefaultTemplate();
 		if(newMap != null) {
-		    NodeModel node = newMap.getRootNode();
-		    final EncryptionModel encryptedMindMapNode = new EncryptionModel(node, new SingleDesEncrypter(password));
-		    node.addExtension(encryptedMindMapNode);
+	    NodeModel node = newMap.getRootNode();
+	    final IEncrypter encrypter = EncryptionHelper.createEncrypter(password);
+	    final EncryptionModel encryptedMindMapNode;
+	    try {
+	        encryptedMindMapNode = new EncryptionModel(node, encrypter);
+	    } catch (Exception e) {
+	        encrypter.destroy();
+	        throw e;
+	    }
+	    node.addExtension(encryptedMindMapNode);
 		    Controller.getCurrentModeController().getMapController().nodeChanged(node);
 		}
 	}
-	
+
 	@Override
 	public void afterMapChange(UserRole userRole) {
 	}

--- a/freeplane/src/main/java/org/freeplane/features/map/EncryptionModel.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/EncryptionModel.java
@@ -63,13 +63,12 @@ public class EncryptionModel implements IExtension {
 	}
 
 	private boolean checkAndSetEncrypter(final IEncrypter encrypter) {
-		final String decryptedNode = decryptXml(encryptedContent, encrypter);
-		if (decryptedNode == null || !decryptedNode.equals("") && !decryptedNode.startsWith("<node ")) {
-			LogUtils.warn("Wrong password supplied (stored!=given).");
-			return false;
+		String decryptedNode = decryptXml(encryptedContent, encrypter);
+		if (decryptedNode != null) {
+			mEncrypter = encrypter;
+			return true;
 		}
-		mEncrypter = encrypter;
-		return true;
+		return false;
 	}
 
 	/**
@@ -110,15 +109,15 @@ public class EncryptionModel implements IExtension {
 		return decrypted;
 	}
 
-	/**
-	 */
 	private String encryptXml(final StringBuffer childXml) {
+		if (mEncrypter == null) {
+			throw new IllegalStateException("Cannot encrypt: encrypter is null");
+		}
 		try {
-			final String encrypted = mEncrypter.encrypt(childXml.toString());
-			return encrypted;
+			return mEncrypter.encrypt(childXml.toString());
 		}
 		catch (final Exception e) {
-			throw new IllegalArgumentException("Can't encrypt the node.", e);
+			throw new IllegalArgumentException("Can't encrypt the node", e);
 		}
 	}
 
@@ -160,6 +159,14 @@ public class EncryptionModel implements IExtension {
 	public boolean isLocked() {
 		return encryptedContent != null;
 	}
+	
+	/**
+	 * Get the encrypted content string. Used for algorithm detection.
+	 * @return the encrypted content, or null if not encrypted
+	 */
+	public String getEncryptedContent() {
+		return encryptedContent;
+	}
 
 	private void pasteXML(final String pasted, final NodeModel target, final MapController mapController) {
 		try {
@@ -188,8 +195,12 @@ public class EncryptionModel implements IExtension {
 				LogUtils.severe("Hidden children replaced");
 			}
 		}
-		else {
-
+	}
+	
+	public void destroy() {
+		if (mEncrypter != null) {
+			mEncrypter.destroy();
+			mEncrypter = null;
 		}
 	}
 }

--- a/freeplane/src/main/java/org/freeplane/features/map/EncryptionModel.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/EncryptionModel.java
@@ -179,6 +179,13 @@ public class EncryptionModel implements IExtension {
 		}
 	}
 
+	public void setEncrypter(IEncrypter encrypter) {
+		if (mEncrypter != null) {
+			mEncrypter.destroy();
+		}
+		mEncrypter = encrypter;
+	}
+
 	synchronized public void unlock() {
 		node.setChildrenInternal(hiddenChildren.remove(node));
 		encryptedContent = null;

--- a/freeplane/src/main/java/org/freeplane/features/map/IEncrypter.java
+++ b/freeplane/src/main/java/org/freeplane/features/map/IEncrypter.java
@@ -25,6 +25,6 @@ package org.freeplane.features.map;
  */
 public interface IEncrypter {
 	public String decrypt(String str);
-
 	public String encrypt(final String str);
+	public void destroy();
 }

--- a/freeplane/src/test/java/org/freeplane/features/encrypt/Aes256EncrypterTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/encrypt/Aes256EncrypterTest.java
@@ -1,0 +1,440 @@
+/*
+ *  Freeplane - mind map editor
+ *  Copyright (C) 2025 Freeplane team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.freeplane.features.encrypt;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.freeplane.features.map.IEncrypter;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Specific tests for AES-256 encryption implementation.
+ * Tests the new encryption algorithm implementation details.
+ * 
+ * @author Freeplane team
+ */
+public class Aes256EncrypterTest {
+	private IEncrypter encrypter;
+
+	@After
+	public void cleanup() {
+		if (encrypter != null) {
+			encrypter.destroy();
+			encrypter = null;
+		}
+	}
+
+	@Test
+	public void encryptedContentHasVersionMarker() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String encrypted = encrypter.encrypt("test");
+		
+		assertThat(encrypted, notNullValue());
+		assertTrue("Encrypted content should start with prefix", 
+			encrypted.startsWith(EncryptionHeader.PREFIX_AES256));
+	}
+
+
+	@Test
+	public void eachEncryptionUsesDifferentSalt() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "test";
+		final String encrypted1 = encrypter.encrypt(plaintext);
+		final String encrypted2 = encrypter.encrypt(plaintext);
+		
+		// Different salt/IV means different ciphertext
+		assertNotEquals(encrypted1, encrypted2);
+	}
+
+	@Test
+	public void differentSaltsProduceDifferentCiphertext() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		// Encrypt same plaintext multiple times
+		final String plaintext = "Hello World";
+		final String encrypted1 = encrypter.encrypt(plaintext);
+		final String encrypted2 = encrypter.encrypt(plaintext);
+		final String encrypted3 = encrypter.encrypt(plaintext);
+		
+		// All should be different
+		assertNotEquals(encrypted1, encrypted2);
+		assertNotEquals(encrypted2, encrypted3);
+		assertNotEquals(encrypted1, encrypted3);
+		
+		// But all should decrypt to the same plaintext
+		assertThat(encrypter.decrypt(encrypted1), equalTo(plaintext));
+		assertThat(encrypter.decrypt(encrypted2), equalTo(plaintext));
+		assertThat(encrypter.decrypt(encrypted3), equalTo(plaintext));
+	}
+
+	@Test
+	public void encryptAndDecryptSimpleText() {
+		final StringBuilder password = new StringBuilder("password");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void encryptAndDecryptEmptyString() {
+		final StringBuilder password = new StringBuilder("password");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void encryptAndDecryptVeryLongText() {
+		final StringBuilder password = new StringBuilder("password");
+		encrypter = new Aes256Encrypter(password);
+		
+		final StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 10000; i++) {
+			sb.append("This is line ").append(i).append(" of a very long text.\n");
+		}
+		final String plaintext = sb.toString();
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void encryptAndDecryptBinaryLikeData() {
+		final StringBuilder password = new StringBuilder("password");
+		encrypter = new Aes256Encrypter(password);
+		
+		// Create string with all ASCII printable characters
+		final StringBuilder sb = new StringBuilder();
+		for (int i = 32; i < 127; i++) {
+			sb.append((char) i);
+		}
+		final String plaintext = sb.toString();
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void encryptAndDecryptUnicodeText() {
+		final StringBuilder password = new StringBuilder("password");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Unicode: 中文 日本語 한글 العربية עברית ελληνικά 🎉🔒📝";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void encryptAndDecryptXmlWithCDATA() {
+		final StringBuilder password = new StringBuilder("password");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "<node><![CDATA[Special <>&\" content]]></node>";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void encryptAndDecryptNewlines() {
+		final StringBuilder password = new StringBuilder("password");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Line 1\nLine 2\rLine 3\r\nLine 4";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void shortPasswordWorks() {
+		final StringBuilder password = new StringBuilder("x");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "test";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void longPasswordWorks() {
+		final StringBuilder password = new StringBuilder();
+		for (int i = 0; i < 500; i++) {
+			password.append("long");
+		}
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "test";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void passwordWithSpacesWorks() {
+		final StringBuilder password = new StringBuilder("pass word with spaces");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "test";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void passwordWithSpecialCharactersWorks() {
+		final StringBuilder password = new StringBuilder("p@ss!w#rd$%^&*()_+-=[]{}|;':\",./<>?`~");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "test";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void passwordWithUnicodeWorks() {
+		final StringBuilder password = new StringBuilder("密码🔐пароль");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "test";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void wrongPasswordReturnsNull() {
+		final StringBuilder password1 = new StringBuilder("correct");
+		final IEncrypter encrypter1 = new Aes256Encrypter(password1);
+		final String encrypted = encrypter1.encrypt("secret");
+		encrypter1.destroy();
+		
+		final StringBuilder password2 = new StringBuilder("wrong");
+		encrypter = new Aes256Encrypter(password2);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void slightlyWrongPasswordReturnsNull() {
+		final StringBuilder password1 = new StringBuilder("password");
+		final IEncrypter encrypter1 = new Aes256Encrypter(password1);
+		final String encrypted = encrypter1.encrypt("secret");
+		encrypter1.destroy();
+		
+		final StringBuilder password2 = new StringBuilder("Password");  // Different case
+		encrypter = new Aes256Encrypter(password2);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void emptyPasswordCannotDecryptNonEmptyPassword() {
+		final StringBuilder password1 = new StringBuilder("password");
+		final IEncrypter encrypter1 = new Aes256Encrypter(password1);
+		final String encrypted = encrypter1.encrypt("secret");
+		encrypter1.destroy();
+		
+		final StringBuilder password2 = new StringBuilder("");
+		encrypter = new Aes256Encrypter(password2);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void destroyMethodCanBeCalled() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		// Should not throw exception
+		encrypter.destroy();
+		encrypter = null;  // Avoid double-destroy in cleanup
+	}
+
+	@Test
+	public void destroyMethodCanBeCalledMultipleTimes() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		// Should not throw exception even when called multiple times
+		encrypter.destroy();
+		encrypter.destroy();
+		encrypter.destroy();
+		encrypter = null;  // Avoid double-destroy in cleanup
+	}
+
+	@Test
+	public void decryptNullReturnsNull() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String decrypted = encrypter.decrypt(null);
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void decryptEmptyStringReturnsNull() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String decrypted = encrypter.decrypt("");
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void decryptInvalidBase64ReturnsNull() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String decrypted = encrypter.decrypt("FP-AES256-V1:not-valid-base64!@#$");
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void decryptTruncatedDataReturnsNull() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String encrypted = encrypter.encrypt("test");
+		// Truncate the encrypted string
+		final String truncated = encrypted.substring(0, encrypted.length() / 2);
+		final String decrypted = encrypter.decrypt(truncated);
+		
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void differentEncrypterInstancesWithSamePasswordWork() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter encrypter1 = new Aes256Encrypter(password);
+		final String plaintext = "Hello World";
+		final String encrypted = encrypter1.encrypt(plaintext);
+		encrypter1.destroy();
+		
+		final IEncrypter encrypter2 = new Aes256Encrypter(password);
+		final String decrypted = encrypter2.decrypt(encrypted);
+		encrypter2.destroy();
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void sameEncrypterInstanceCanEncryptAndDecryptMultipleTimes() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		for (int i = 0; i < 10; i++) {
+			final String plaintext = "Message " + i;
+			final String encrypted = encrypter.encrypt(plaintext);
+			final String decrypted = encrypter.decrypt(encrypted);
+			assertThat(decrypted, equalTo(plaintext));
+		}
+	}
+
+	@Test
+	public void encryptedContentIsNotPlaintext() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "This is secret";
+		final String encrypted = encrypter.encrypt(plaintext);
+		
+		assertThat(encrypted, not(equalTo(plaintext)));
+		assertThat(encrypted.contains("This is secret"), equalTo(false));
+	}
+
+	@Test
+	public void encryptedContentIsLongerThanPlaintext() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Hi";
+		final String encrypted = encrypter.encrypt(plaintext);
+		
+		assertTrue("Encrypted content should be longer", encrypted.length() > plaintext.length());
+	}
+
+	@Test
+	public void encryptedContentContainsThreeParts() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "test";
+		final String encrypted = encrypter.encrypt(plaintext);
+		
+		assertTrue("Encrypted content should start with prefix", 
+			encrypted.startsWith(EncryptionHeader.PREFIX_AES256));
+		
+		String base64Data = EncryptionHeader.stripPrefix(encrypted);
+		assertThat("Should have base64 data after prefix", base64Data, notNullValue());
+		
+		final byte[] decoded = DesEncrypter.fromBase64(base64Data);
+		
+		// Format: 16-byte salt + 16-byte IV + ciphertext
+		assertTrue("Encrypted content should have salt + IV + ciphertext", 
+			decoded.length >= 48);
+	}
+
+	@Test
+	public void newFormatUsesPlainTextPrefix() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String encrypted = encrypter.encrypt("test");
+		
+		assertTrue("Encryption should use prefix",
+			encrypted.startsWith("FP-AES256-V1:"));
+	}
+}
+

--- a/freeplane/src/test/java/org/freeplane/features/encrypt/EncryptionHeaderTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/encrypt/EncryptionHeaderTest.java
@@ -1,0 +1,99 @@
+/*
+ *  Freeplane - mind map editor
+ *  Copyright (C) 2025 Freeplane team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.freeplane.features.encrypt;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.Test;
+
+/**
+ * Tests for the encryption header format (plain text prefixes).
+ */
+public class EncryptionHeaderTest {
+
+	@Test
+	public void detectsAes256Prefix() {
+		String encrypted = "FP-AES256-V1:c29tZWJhc2U2NGRhdGE=";
+		
+		assertThat(encrypted.startsWith(EncryptionHeader.PREFIX_AES256), equalTo(true));
+	}
+
+	@Test
+	public void stripsPrefixCorrectly() {
+		String encrypted = "FP-AES256-V1:c29tZWJhc2U2NGRhdGE=";
+		String stripped = EncryptionHeader.stripPrefix(encrypted);
+		
+		assertThat(stripped, equalTo("c29tZWJhc2U2NGRhdGE="));
+	}
+
+	@Test
+	public void stripPrefixReturnsNullForNonPrefixedString() {
+		String encrypted = "c29tZWJhc2U2NGRhdGE=";
+		String stripped = EncryptionHeader.stripPrefix(encrypted);
+		
+		assertThat(stripped, nullValue());
+	}
+
+	@Test
+	public void legacyDesHasNoPrefix() {
+		String legacyFormat = "qZvIMlY14wM c29tZWVuY3J5cHRlZGRhdGE=";
+		
+		assertThat(legacyFormat.startsWith(EncryptionHeader.PREFIX_AES256), equalTo(false));
+	}
+
+	@Test
+	public void aes256EncryptedContentHasHeader() {
+		final StringBuilder password = new StringBuilder("test123");
+		Aes256Encrypter encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted = encrypter.encrypt(plaintext);
+		
+		assertThat(encrypted.startsWith(EncryptionHeader.PREFIX_AES256), equalTo(true));
+		
+		encrypter.destroy();
+	}
+
+	@Test
+	public void aes256CanDecryptContentWithHeader() {
+		final StringBuilder password = new StringBuilder("test123");
+		Aes256Encrypter encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "<node TEXT=\"test\" ID=\"ID_123\"/>";
+		final String encrypted = encrypter.encrypt(plaintext);
+		
+		final String decrypted = encrypter.decrypt(encrypted);
+		assertThat(decrypted, equalTo(plaintext));
+		
+		encrypter.destroy();
+	}
+	
+	@Test
+	public void newEncryptedContentUsesPlainTextPrefix() {
+		final StringBuilder password = new StringBuilder("test123");
+		Aes256Encrypter encrypter = new Aes256Encrypter(password);
+		
+		final String encrypted = encrypter.encrypt("test");
+		
+		assertThat(encrypted.startsWith("FP-AES256-V1:"), equalTo(true));
+		
+		encrypter.destroy();
+	}
+}

--- a/freeplane/src/test/java/org/freeplane/features/encrypt/EncryptionHelperTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/encrypt/EncryptionHelperTest.java
@@ -1,0 +1,380 @@
+/*
+ *  Freeplane - mind map editor
+ *  Copyright (C) 2025 Freeplane team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.freeplane.features.encrypt;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.freeplane.features.map.IEncrypter;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Tests for EncryptionHelper - algorithm detection and backward compatibility.
+ * 
+ * @author Freeplane team
+ */
+public class EncryptionHelperTest {
+	private IEncrypter encrypter;
+
+	@After
+	public void cleanup() {
+		if (encrypter != null) {
+			encrypter.destroy();
+			encrypter = null;
+		}
+	}
+
+	@Test
+	public void createEncrypterReturnsAes256() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = EncryptionHelper.createEncrypter(password);
+		
+		assertThat(encrypter, notNullValue());
+		assertThat(encrypter.getClass().getSimpleName(), equalTo("Aes256Encrypter"));
+	}
+
+	@Test
+	public void createEncrypterCanEncryptAndDecrypt() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = EncryptionHelper.createEncrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void createDecrypterDetectsAes256() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter aesEncrypter = new Aes256Encrypter(password);
+		final String encrypted = aesEncrypter.encrypt("Hello World");
+		aesEncrypter.destroy();
+		
+		encrypter = EncryptionHelper.createDecrypter(password, encrypted);
+		
+		assertThat(encrypter, notNullValue());
+		assertThat(encrypter.getClass().getSimpleName(), equalTo("Aes256Encrypter"));
+		assertThat(encrypter.decrypt(encrypted), equalTo("Hello World"));
+	}
+
+	@Test
+	public void createDecrypterFallsBackToSingleDesForLegacyContent() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter desEncrypter = new SingleDesEncrypter(password);
+		final String encrypted = desEncrypter.encrypt("Hello World");
+		desEncrypter.destroy();
+		
+		encrypter = EncryptionHelper.createDecrypter(password, encrypted);
+		
+		assertThat(encrypter, notNullValue());
+		assertThat(encrypter.getClass().getSimpleName(), equalTo("SingleDesEncrypter"));
+	}
+
+	@Test
+	public void createDecrypterDefaultsToAes256WhenContentIsNull() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = EncryptionHelper.createDecrypter(password, null);
+		
+		assertThat(encrypter, notNullValue());
+		assertThat(encrypter.getClass().getSimpleName(), equalTo("Aes256Encrypter"));
+	}
+
+	@Test
+	public void tryDecryptWithAllAlgorithmsDecryptsAes256() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter aesEncrypter = new Aes256Encrypter(password);
+		final String plaintext = "Hello World";
+		final String encrypted = aesEncrypter.encrypt(plaintext);
+		aesEncrypter.destroy();
+		
+		final String decrypted = EncryptionHelper.createDecrypter(password, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void tryDecryptWithAllAlgorithmsDecryptsSingleDes() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter desEncrypter = new SingleDesEncrypter(password);
+		final String plaintext = "<node TEXT=\"test\"/>";
+		final String encrypted = desEncrypter.encrypt(plaintext);
+		desEncrypter.destroy();
+		
+		final String decrypted = EncryptionHelper.createDecrypter(password, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void tryDecryptWithAllAlgorithmsReturnsNullForWrongPassword() {
+		final StringBuilder password1 = new StringBuilder("correct");
+		final IEncrypter aesEncrypter = new Aes256Encrypter(password1);
+		final String encrypted = aesEncrypter.encrypt("Secret");
+		aesEncrypter.destroy();
+		
+		final StringBuilder password2 = new StringBuilder("wrong");
+		final String decrypted = EncryptionHelper.createDecrypter(password2, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void tryDecryptWithAllAlgorithmsReturnsNullForNull() {
+		final StringBuilder password = new StringBuilder("test123");
+		final String decrypted = EncryptionHelper.createDecrypter(password, null).decrypt(null);
+		
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void tryDecryptWithAllAlgorithmsReturnsNullForInvalidData() {
+		final StringBuilder password = new StringBuilder("test123");
+		final String decrypted = EncryptionHelper.createDecrypter(password, "not-encrypted-data").decrypt("not-encrypted-data");
+		
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void tryDecryptWithAllAlgorithmsHandlesEmptyEncryptedContent() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter aesEncrypter = new Aes256Encrypter(password);
+		final String encrypted = aesEncrypter.encrypt("");
+		aesEncrypter.destroy();
+		
+		final String decrypted = EncryptionHelper.createDecrypter(password, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(""));
+	}
+
+	@Test
+	public void tryDecryptWithAllAlgorithmsRejectsInvalidXml() {
+		final StringBuilder password = new StringBuilder("test123");
+		
+		// Create a DES-encrypted content that's not valid XML
+		// (This simulates what might happen with wrong password producing garbage)
+		final String decrypted = EncryptionHelper.createDecrypter(password, "invalid").decrypt("invalid");
+		
+		// Should return null because validation fails
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void tryDecryptWithAllAlgorithmsAcceptsValidXml() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter desEncrypter = new SingleDesEncrypter(password);
+		final String validXml = "<node TEXT=\"test\"><node TEXT=\"child\"/></node>";
+		final String encrypted = desEncrypter.encrypt(validXml);
+		desEncrypter.destroy();
+		
+		final String decrypted = EncryptionHelper.createDecrypter(password, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(validXml));
+	}
+
+	@Test
+	public void tryDecryptWithAllAlgorithmsAcceptsSelfClosingNode() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter desEncrypter = new SingleDesEncrypter(password);
+		final String validXml = "<node TEXT=\"test\"/>";
+		final String encrypted = desEncrypter.encrypt(validXml);
+		desEncrypter.destroy();
+		
+		final String decrypted = EncryptionHelper.createDecrypter(password, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(validXml));
+	}
+
+	@Test
+	public void getEncryptionAlgorithmDescriptionForAes256() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter aesEncrypter = new Aes256Encrypter(password);
+		final String encrypted = aesEncrypter.encrypt("test");
+		aesEncrypter.destroy();
+		
+		final String description = EncryptionHelper.getEncryptionAlgorithmDescription(encrypted);
+		
+		assertThat(description, equalTo("AES-256"));
+	}
+
+	@Test
+	public void getEncryptionAlgorithmDescriptionForLegacyDes() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter desEncrypter = new SingleDesEncrypter(password);
+		final String encrypted = desEncrypter.encrypt("test");
+		desEncrypter.destroy();
+		
+		final String description = EncryptionHelper.getEncryptionAlgorithmDescription(encrypted);
+		
+		assertThat(description, equalTo("DES"));
+	}
+
+	@Test
+	public void getEncryptionAlgorithmDescriptionForNull() {
+		final String description = EncryptionHelper.getEncryptionAlgorithmDescription(null);
+		
+		assertThat(description, equalTo("Unknown"));
+	}
+
+	@Test
+	public void legacyContentCanBeDecryptedWithHelper() {
+		final StringBuilder password = new StringBuilder("test123");
+		
+		// Encrypt with legacy SingleDES
+		final IEncrypter desEncrypter = new SingleDesEncrypter(password);
+		final String plaintext = "<node TEXT=\"legacy content\"/>";
+		final String encrypted = desEncrypter.encrypt(plaintext);
+		desEncrypter.destroy();
+		
+		// Use helper to decrypt (should work with fallback)
+		final String decrypted = EncryptionHelper.createDecrypter(password, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void aes256ContentCanBeDecryptedWithHelper() {
+		final StringBuilder password = new StringBuilder("test123");
+		
+		// Encrypt with AES-256
+		final IEncrypter aesEncrypter = new Aes256Encrypter(password);
+		final String plaintext = "<node TEXT=\"new content\"/>";
+		final String encrypted = aesEncrypter.encrypt(plaintext);
+		aesEncrypter.destroy();
+		
+		// Use helper to decrypt (should work directly)
+		final String decrypted = EncryptionHelper.createDecrypter(password, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void mixedAlgorithmsCanBeDecryptedSequentially() {
+		final StringBuilder password = new StringBuilder("test123");
+		
+		// Create content with different algorithms
+		final IEncrypter aesEncrypter = new Aes256Encrypter(password);
+		final String plaintext1 = "<node TEXT=\"aes content\"/>";
+		final String encrypted1 = aesEncrypter.encrypt(plaintext1);
+		aesEncrypter.destroy();
+		
+		final IEncrypter desEncrypter = new SingleDesEncrypter(password);
+		final String plaintext2 = "<node TEXT=\"des content\"/>";
+		final String encrypted2 = desEncrypter.encrypt(plaintext2);
+		desEncrypter.destroy();
+		
+		// Decrypt both with helper
+		final String decrypted1 = EncryptionHelper.createDecrypter(password, encrypted1).decrypt(encrypted1);
+		final String decrypted2 = EncryptionHelper.createDecrypter(password, encrypted2).decrypt(encrypted2);
+		
+		assertThat(decrypted1, equalTo(plaintext1));
+		assertThat(decrypted2, equalTo(plaintext2));
+	}
+
+	@Test
+	public void tryDecryptWithAllAlgorithmsFallsBackToDESWhenAES256Fails() {
+		final StringBuilder password = new StringBuilder("test123");
+		
+		final IEncrypter desEncrypter = new SingleDesEncrypter(password);
+		final String plaintext = "<node TEXT=\"legacy content\"/>";
+		final String encrypted = desEncrypter.encrypt(plaintext);
+		desEncrypter.destroy();
+		
+		final String decrypted = EncryptionHelper.createDecrypter(password, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+	
+	/**
+	 * Test that ensures even when AES-256 is attempted first and fails,
+	 * the fallback to legacy algorithms still works.
+	 */
+	@Test
+	public void tryDecryptWithAllAlgorithmsTriesAllAlgorithmsWhenFirstFails() {
+		final StringBuilder correctPassword = new StringBuilder("correct");
+		final StringBuilder wrongPassword = new StringBuilder("wrong");
+		
+		// Encrypt with DES
+		final IEncrypter desEncrypter = new SingleDesEncrypter(correctPassword);
+		final String plaintext = "<node TEXT=\"test content\"/>";
+		final String encrypted = desEncrypter.encrypt(plaintext);
+		desEncrypter.destroy();
+		
+		// First verify that wrong password fails with all algorithms
+		final String decryptedWrong = EncryptionHelper.createDecrypter(wrongPassword, encrypted).decrypt(encrypted);
+		assertThat(decryptedWrong, nullValue());
+		
+		// Then verify that correct password succeeds (tests the fallback chain)
+		final String decryptedCorrect = EncryptionHelper.createDecrypter(correctPassword, encrypted).decrypt(encrypted);
+		assertThat(decryptedCorrect, equalTo(plaintext));
+	}
+
+	@Test
+	public void complexXmlWithMultipleNodesCanBeEncryptedAndDecrypted() {
+		final StringBuilder password = new StringBuilder("myPassword123");
+		encrypter = EncryptionHelper.createEncrypter(password);
+		
+		final String complexXml = "<node TEXT=\"Parent\" ID=\"ID_1\">" +
+			"<node TEXT=\"Child 1\" ID=\"ID_2\">" +
+			"<node TEXT=\"Grandchild\" ID=\"ID_3\"/>" +
+			"</node>" +
+			"<node TEXT=\"Child 2\" ID=\"ID_4\"/>" +
+			"</node>";
+		
+		final String encrypted = encrypter.encrypt(complexXml);
+		final String decrypted = EncryptionHelper.createDecrypter(password, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(complexXml));
+	}
+
+	@Test
+	public void xmlWithAttributesCanBeEncryptedAndDecrypted() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = EncryptionHelper.createEncrypter(password);
+		
+		final String xmlWithAttributes = "<node TEXT=\"Test\" " +
+			"ID=\"ID_123\" " +
+			"CREATED=\"1234567890\" " +
+			"MODIFIED=\"1234567891\" " +
+			"POSITION=\"right\" " +
+			"STYLE_REF=\"default\"/>";
+		
+		final String encrypted = encrypter.encrypt(xmlWithAttributes);
+		final String decrypted = EncryptionHelper.createDecrypter(password, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(xmlWithAttributes));
+	}
+
+	@Test
+	public void xmlWithSpecialCharactersInTextCanBeEncryptedAndDecrypted() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = EncryptionHelper.createEncrypter(password);
+		
+		final String xmlWithSpecialChars = "<node TEXT=\"Test &lt;&gt;&amp;&quot; special\"/>";
+		
+		final String encrypted = encrypter.encrypt(xmlWithSpecialChars);
+		final String decrypted = EncryptionHelper.createDecrypter(password, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(xmlWithSpecialChars));
+	}
+}
+

--- a/freeplane/src/test/java/org/freeplane/features/encrypt/EncryptionModelTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/encrypt/EncryptionModelTest.java
@@ -1,0 +1,364 @@
+/*
+ *  Freeplane - mind map editor
+ *  Copyright (C) 2025 Freeplane team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.freeplane.features.encrypt;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.freeplane.features.map.EncryptionModel;
+import org.freeplane.features.map.IEncrypter;
+import org.freeplane.features.map.NodeModel;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Tests for EncryptionModel - high-level encryption model functionality.
+ * 
+ * @author Freeplane team
+ */
+public class EncryptionModelTest {
+	private IEncrypter encrypter;
+
+	@After
+	public void cleanup() {
+		if (encrypter != null) {
+			encrypter.destroy();
+			encrypter = null;
+		}
+	}
+
+	@Test
+	public void createEncryptionModelWithEncrypter() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final NodeModel node = new NodeModel("test", null);
+		final EncryptionModel model = new EncryptionModel(node, encrypter);
+		
+		assertThat(model, notNullValue());
+		assertTrue("Model should be accessible when created with encrypter", model.isAccessible());
+		assertFalse("Model should not be locked when created with encrypter", model.isLocked());
+	}
+
+	@Test
+	public void createEncryptionModelWithEncryptedContent() {
+		final NodeModel node = new NodeModel("test", null);
+		final String encryptedContent = "encrypted-data";
+		final EncryptionModel model = new EncryptionModel(node, encryptedContent);
+		
+		assertThat(model, notNullValue());
+		assertFalse("Model should not be accessible when created with encrypted content", model.isAccessible());
+		assertTrue("Model should be locked when created with encrypted content", model.isLocked());
+	}
+
+	@Test
+	public void getModelReturnsNullForNodeWithoutEncryption() {
+		final NodeModel node = new NodeModel("test", null);
+		final EncryptionModel model = EncryptionModel.getModel(node);
+		
+		assertThat(model, nullValue());
+	}
+
+	@Test
+	public void getModelReturnsEncryptionModelForEncryptedNode() {
+		final NodeModel node = new NodeModel("test", null);
+		final String encryptedContent = "encrypted-data";
+		final EncryptionModel model = new EncryptionModel(node, encryptedContent);
+		node.addExtension(model);
+		
+		final EncryptionModel retrieved = EncryptionModel.getModel(node);
+		
+		assertThat(retrieved, notNullValue());
+		assertThat(retrieved, equalTo(model));
+	}
+
+	@Test
+	public void newModelWithEncrypterIsAccessible() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final NodeModel node = new NodeModel("test", null);
+		final EncryptionModel model = new EncryptionModel(node, encrypter);
+		
+		assertTrue(model.isAccessible());
+		assertFalse(model.isLocked());
+	}
+
+	@Test
+	public void newModelWithEncryptedContentIsLocked() {
+		final NodeModel node = new NodeModel("test", null);
+		final EncryptionModel model = new EncryptionModel(node, "encrypted");
+		
+		assertFalse(model.isAccessible());
+		assertTrue(model.isLocked());
+	}
+
+	@Test
+	public void getEncryptedContentReturnsNullForAccessibleModel() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final NodeModel node = new NodeModel("test", null);
+		final EncryptionModel model = new EncryptionModel(node, encrypter);
+		
+		assertThat(model.getEncryptedContent(), nullValue());
+	}
+
+	@Test
+	public void getEncryptedContentReturnsContentForLockedModel() {
+		final NodeModel node = new NodeModel("test", null);
+		final String encryptedContent = "encrypted-data";
+		final EncryptionModel model = new EncryptionModel(node, encryptedContent);
+		
+		assertThat(model.getEncryptedContent(), equalTo(encryptedContent));
+	}
+
+	@Test
+	public void destroyMethodCanBeCalled() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter localEncrypter = new Aes256Encrypter(password);
+		
+		final NodeModel node = new NodeModel("test", null);
+		final EncryptionModel model = new EncryptionModel(node, localEncrypter);
+		
+		// Should not throw exception
+		model.destroy();
+	}
+
+	@Test
+	public void destroyMethodCanBeCalledMultipleTimes() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter localEncrypter = new Aes256Encrypter(password);
+		
+		final NodeModel node = new NodeModel("test", null);
+		final EncryptionModel model = new EncryptionModel(node, localEncrypter);
+		
+		// Should not throw exception even when called multiple times
+		model.destroy();
+		model.destroy();
+		model.destroy();
+	}
+
+	@Test
+	public void destroyOnModelWithEncryptedContentDoesNotThrow() {
+		final NodeModel node = new NodeModel("test", null);
+		final EncryptionModel model = new EncryptionModel(node, "encrypted");
+		
+		// Should not throw exception
+		model.destroy();
+	}
+
+	@Test
+	public void aes256EncryptedContentIsDetectable() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter aesEncrypter = new Aes256Encrypter(password);
+		final String encrypted = aesEncrypter.encrypt("<node TEXT=\"test\"/>");
+		aesEncrypter.destroy();
+		
+		assertTrue("AES-256 content should be detectable", 
+			encrypted.startsWith(EncryptionHeader.PREFIX_AES256));
+	}
+
+	@Test
+	public void legacyDesContentIsNotDetectedAsAes256() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter desEncrypter = new SingleDesEncrypter(password);
+		final String encrypted = desEncrypter.encrypt("<node TEXT=\"test\"/>");
+		desEncrypter.destroy();
+		
+		assertFalse("Legacy DES content should not be detected as AES-256", 
+			encrypted.startsWith(EncryptionHeader.PREFIX_AES256));
+	}
+
+	@Test
+	public void aes256EncryptionProducesCorrectFormat() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = EncryptionHelper.createEncrypter(password);
+		
+		final String plaintext = "<node TEXT=\"test\"/>";
+		final String encrypted = encrypter.encrypt(plaintext);
+		
+		assertTrue("New encryption should use AES-256", 
+			encrypted.startsWith(EncryptionHeader.PREFIX_AES256));
+	}
+
+	@Test
+	public void legacyDesContentDoesNotHaveAes256Marker() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter desEncrypter = new SingleDesEncrypter(password);
+		
+		final String plaintext = "<node TEXT=\"test\"/>";
+		final String encrypted = desEncrypter.encrypt(plaintext);
+		desEncrypter.destroy();
+		
+		assertFalse("Legacy DES content should not have AES-256 marker", 
+			encrypted.startsWith("FP-AES256-V1:"));
+	}
+
+	@Test
+	public void encryptEmptyXmlContent() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void multipleNodesCanBeEncryptedIndependently() {
+		final StringBuilder password = new StringBuilder("test123");
+		
+		final NodeModel node1 = new NodeModel("node1", null);
+		final IEncrypter encrypter1 = new Aes256Encrypter(password);
+		final EncryptionModel model1 = new EncryptionModel(node1, encrypter1);
+		node1.addExtension(model1);
+		
+		final NodeModel node2 = new NodeModel("node2", null);
+		final IEncrypter encrypter2 = new Aes256Encrypter(password);
+		final EncryptionModel model2 = new EncryptionModel(node2, encrypter2);
+		node2.addExtension(model2);
+		
+		assertThat(EncryptionModel.getModel(node1), notNullValue());
+		assertThat(EncryptionModel.getModel(node2), notNullValue());
+		assertThat(EncryptionModel.getModel(node1), equalTo(model1));
+		assertThat(EncryptionModel.getModel(node2), equalTo(model2));
+	}
+
+	@Test
+	public void encryptSimpleNodeXml() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "<node TEXT=\"My Secret\" ID=\"ID_123\"/>";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void encryptNestedNodeXml() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "<node TEXT=\"Parent\" ID=\"ID_1\">" +
+			"<node TEXT=\"Child\" ID=\"ID_2\"/>" +
+			"</node>";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void encryptComplexNodeXmlWithAttributes() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "<node TEXT=\"Complex Node\" " +
+			"ID=\"ID_123\" " +
+			"CREATED=\"1234567890\" " +
+			"MODIFIED=\"1234567891\" " +
+			"POSITION=\"right\" " +
+			"STYLE_REF=\"default\" " +
+			"FOLDED=\"true\">" +
+			"<node TEXT=\"Child 1\" ID=\"ID_124\"/>" +
+			"<node TEXT=\"Child 2\" ID=\"ID_125\">" +
+			"<node TEXT=\"Grandchild\" ID=\"ID_126\"/>" +
+			"</node>" +
+			"</node>";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void encryptNodeWithSpecialXmlCharacters() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "<node TEXT=\"Test &lt;&gt;&amp;&quot;&apos; special\"/>";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void aes256AlgorithmDescriptionIsCorrect() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter aesEncrypter = new Aes256Encrypter(password);
+		final String encrypted = aesEncrypter.encrypt("test");
+		aesEncrypter.destroy();
+		
+		final String description = EncryptionHelper.getEncryptionAlgorithmDescription(encrypted);
+		assertThat(description, equalTo("AES-256"));
+	}
+
+	@Test
+	public void legacyDesAlgorithmDescriptionIsCorrect() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter desEncrypter = new SingleDesEncrypter(password);
+		final String encrypted = desEncrypter.encrypt("test");
+		desEncrypter.destroy();
+		
+		final String description = EncryptionHelper.getEncryptionAlgorithmDescription(encrypted);
+		assertThat(description, equalTo("DES"));
+	}
+
+	@Test
+	public void canDecryptLegacyDesContentWithFallback() {
+		final StringBuilder password = new StringBuilder("test123");
+		
+		// Create legacy DES encrypted content
+		final IEncrypter desEncrypter = new SingleDesEncrypter(password);
+		final String plaintext = "<node TEXT=\"legacy\"/>";
+		final String encrypted = desEncrypter.encrypt(plaintext);
+		desEncrypter.destroy();
+		
+		// Try to decrypt with helper (should work via fallback)
+		final String decrypted = EncryptionHelper.createDecrypter(password, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void canDecryptNewAes256ContentDirectly() {
+		final StringBuilder password = new StringBuilder("test123");
+		
+		// Create new AES-256 encrypted content
+		final IEncrypter aesEncrypter = new Aes256Encrypter(password);
+		final String plaintext = "<node TEXT=\"new\"/>";
+		final String encrypted = aesEncrypter.encrypt(plaintext);
+		aesEncrypter.destroy();
+		
+		// Try to decrypt with helper (should work directly)
+		final String decrypted = EncryptionHelper.createDecrypter(password, encrypted).decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+}
+

--- a/freeplane/src/test/java/org/freeplane/features/encrypt/EncryptionTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/encrypt/EncryptionTest.java
@@ -1,0 +1,312 @@
+/*
+ *  Freeplane - mind map editor
+ *  Copyright (C) 2025 Freeplane team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.freeplane.features.encrypt;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertNotEquals;
+
+import org.freeplane.features.map.IEncrypter;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Comprehensive tests for encryption functionality.
+ * Tests all encryption algorithms (AES-256, TripleDES, SingleDES) and backward compatibility.
+ * 
+ * @author Freeplane team
+ */
+public class EncryptionTest {
+	private IEncrypter encrypter;
+
+	@After
+	public void cleanup() {
+		if (encrypter != null) {
+			encrypter.destroy();
+			encrypter = null;
+		}
+	}
+
+	@Test
+	public void aes256EncryptAndDecrypt() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void aes256EncryptEmptyString() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void aes256EncryptUnicodeText() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Hello 世界 🌍 Привет мир";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void aes256EncryptXmlContent() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "<node TEXT=\"test\" ID=\"ID_123\"><node TEXT=\"child\"/></node>";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void aes256EncryptLongText() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 1000; i++) {
+			sb.append("This is a long text to test encryption of large content. ");
+		}
+		final String plaintext = sb.toString();
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void aes256EncryptWithSpecialCharacters() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Special chars: !@#$%^&*()_+-=[]{}|;':\",./<>?`~\n\t\r";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void aes256DecryptWithWrongPassword() {
+		final StringBuilder password1 = new StringBuilder("correct");
+		final IEncrypter encrypter1 = new Aes256Encrypter(password1);
+		
+		final String plaintext = "Secret message";
+		final String encrypted = encrypter1.encrypt(plaintext);
+		encrypter1.destroy();
+		
+		final StringBuilder password2 = new StringBuilder("wrong");
+		encrypter = new Aes256Encrypter(password2);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void aes256EncryptedContentIsDifferent() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted = encrypter.encrypt(plaintext);
+		
+		assertThat(encrypted, notNullValue());
+		assertThat(encrypted, not(equalTo(plaintext)));
+	}
+
+	@Test
+	public void aes256EncryptedContentHasVersionMarker() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted = encrypter.encrypt(plaintext);
+		
+		assertThat(encrypted.startsWith(EncryptionHeader.PREFIX_AES256), equalTo(true));
+	}
+
+	@Test
+	public void aes256SameContentEncryptedTwiceIsDifferent() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted1 = encrypter.encrypt(plaintext);
+		final String encrypted2 = encrypter.encrypt(plaintext);
+		
+		// Different because of different salts/IVs
+		assertNotEquals(encrypted1, encrypted2);
+		
+		// But both decrypt to the same plaintext
+		assertThat(encrypter.decrypt(encrypted1), equalTo(plaintext));
+		assertThat(encrypter.decrypt(encrypted2), equalTo(plaintext));
+	}
+
+	@Test
+	public void aes256DecryptNull() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String decrypted = encrypter.decrypt(null);
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void singleDesEncryptAndDecrypt() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new SingleDesEncrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void singleDesEncryptEmptyString() {
+		final StringBuilder password = new StringBuilder("test123");
+		encrypter = new SingleDesEncrypter(password);
+		
+		final String plaintext = "";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void singleDesDecryptWithWrongPassword() {
+		final StringBuilder password1 = new StringBuilder("correct");
+		final IEncrypter encrypter1 = new SingleDesEncrypter(password1);
+		
+		final String plaintext = "Secret message";
+		final String encrypted = encrypter1.encrypt(plaintext);
+		encrypter1.destroy();
+		
+		final StringBuilder password2 = new StringBuilder("wrong");
+		encrypter = new SingleDesEncrypter(password2);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void aes256CannotDecryptSingleDesContent() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter desEncrypter = new SingleDesEncrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted = desEncrypter.encrypt(plaintext);
+		desEncrypter.destroy();
+		
+		encrypter = new Aes256Encrypter(password);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		// AES-256 cannot directly decrypt DES content (returns null)
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void singleDesCannotDecryptAes256Content() {
+		final StringBuilder password = new StringBuilder("test123");
+		final IEncrypter aesEncrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted = aesEncrypter.encrypt(plaintext);
+		aesEncrypter.destroy();
+		
+		encrypter = new SingleDesEncrypter(password);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		// SingleDES cannot decrypt AES-256 content (returns null)
+		assertThat(decrypted, nullValue());
+	}
+
+	@Test
+	public void encryptWithEmptyPassword() {
+		final StringBuilder password = new StringBuilder("");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void encryptWithVeryLongPassword() {
+		final StringBuilder password = new StringBuilder();
+		for (int i = 0; i < 1000; i++) {
+			password.append("x");
+		}
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void encryptWithUnicodePassword() {
+		final StringBuilder password = new StringBuilder("密码🔒пароль");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+
+	@Test
+	public void encryptWithSpecialCharactersInPassword() {
+		final StringBuilder password = new StringBuilder("p@$$w0rd!#%^&*()");
+		encrypter = new Aes256Encrypter(password);
+		
+		final String plaintext = "Hello World";
+		final String encrypted = encrypter.encrypt(plaintext);
+		final String decrypted = encrypter.decrypt(encrypted);
+		
+		assertThat(decrypted, equalTo(plaintext));
+	}
+}
+


### PR DESCRIPTION
This is the continuation of another pull request that was reverted (73858dd).

The other pull request did actually work when creating **new** maps or nodes, but it did not overwrite legacy DES maps with the new AES-256 scheme. That was based on a misunderstanding. 

I have now updated the code so that when a user unlocks a legacy DES-encrypted node and re-locks it, the node is re-encrypted with AES-256 instead. This means BOTH new encryptions and legacy maps will automatically migrate to AES-256 through normal use (unlock/lock cycles).

I have done a series of tests and verifications. i.e. edit legacy encrypted maps to see whether they are overwritten with AES-256, and edit new maps. When checking the mm files, AES-256 (64 hex characters) appear as expected
The automatical tests also execute successfully.

The solution is in the following 4 lines in EncryptionController.java:

```
if (decrypted) {
            final IEncrypter aesEncrypter = EncryptionHelper.createEncrypter(password);
            encryptionModel.setEncrypter(aesEncrypter);
            tempEncrypter.destroy();
```
