### PR TITLE
Fix problematic test by switching to AES-GCM

### DIFF
--- a/freeplane/src/main/java/org/freeplane/features/encrypt/Aes256Encrypter.java
+++ b/freeplane/src/main/java/org/freeplane/features/encrypt/Aes256Encrypter.java
@@ -26,13 +26,14 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.util.Arrays;
 
+import javax.crypto.AEADBadTagException;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -41,10 +42,10 @@ import org.freeplane.features.map.IEncrypter;
 
 public class Aes256Encrypter implements IEncrypter {
 	private static final int SALT_LENGTH = 16;
-	private static final int IV_LENGTH = 16;
+	private static final int IV_LENGTH = 12;
 	private static final int KEY_LENGTH = 256;
 	private static final String KEY_DERIVATION_ALGORITHM = "PBKDF2WithHmacSHA256";
-	private static final String CIPHER_ALGORITHM = "AES/CBC/PKCS5Padding";
+	private static final String CIPHER_ALGORITHM = "AES/GCM/NoPadding";
 	private static final int ITERATION_COUNT = 100000;
 	
 	private Cipher dcipher;
@@ -94,6 +95,8 @@ public class Aes256Encrypter implements IEncrypter {
 			}
 			final byte[] utf8 = dcipher.doFinal(ciphertext);
 			return new String(utf8, StandardCharsets.UTF_8);
+		}
+		catch (final AEADBadTagException e) {
 		}
 		catch (final BadPaddingException e) {
 		}
@@ -162,14 +165,14 @@ public class Aes256Encrypter implements IEncrypter {
 				if (iv == null) {
 					currentIV = new byte[IV_LENGTH];
 					secureRandom.nextBytes(currentIV);
-					final IvParameterSpec ivSpec = new IvParameterSpec(currentIV);
+					final GCMParameterSpec gcmSpec = new GCMParameterSpec(128, currentIV);
 					ecipher = Cipher.getInstance(CIPHER_ALGORITHM);
-					ecipher.init(Cipher.ENCRYPT_MODE, key, ivSpec);
+					ecipher.init(Cipher.ENCRYPT_MODE, key, gcmSpec);
 				} else {
 					currentIV = iv;
-					final IvParameterSpec ivSpec = new IvParameterSpec(currentIV);
+					final GCMParameterSpec gcmSpec = new GCMParameterSpec(128, currentIV);
 					dcipher = Cipher.getInstance(CIPHER_ALGORITHM);
-					dcipher.init(Cipher.DECRYPT_MODE, key, ivSpec);
+					dcipher.init(Cipher.DECRYPT_MODE, key, gcmSpec);
 				}
 			}
 			catch (final InvalidAlgorithmParameterException e) {

--- a/freeplane/src/test/java/org/freeplane/features/encrypt/Aes256EncrypterTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/encrypt/Aes256EncrypterTest.java
@@ -17,24 +17,12 @@
  */
 package org.freeplane.features.encrypt;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.freeplane.features.map.IEncrypter;
 import org.junit.After;
 import org.junit.Test;
 
-/**
- * Specific tests for AES-256 encryption implementation.
- * Tests the new encryption algorithm implementation details.
- * 
- * @author Freeplane team
- */
 public class Aes256EncrypterTest {
 	private IEncrypter encrypter;
 
@@ -53,9 +41,8 @@ public class Aes256EncrypterTest {
 		
 		final String encrypted = encrypter.encrypt("test");
 		
-		assertThat(encrypted, notNullValue());
-		assertTrue("Encrypted content should start with prefix", 
-			encrypted.startsWith(EncryptionHeader.PREFIX_AES256));
+		assertThat(encrypted).isNotNull();
+		assertThat(encrypted).startsWith(EncryptionHeader.PREFIX_AES256);
 	}
 
 
@@ -68,8 +55,7 @@ public class Aes256EncrypterTest {
 		final String encrypted1 = encrypter.encrypt(plaintext);
 		final String encrypted2 = encrypter.encrypt(plaintext);
 		
-		// Different salt/IV means different ciphertext
-		assertNotEquals(encrypted1, encrypted2);
+		assertThat(encrypted1).isNotEqualTo(encrypted2);
 	}
 
 	@Test
@@ -77,21 +63,18 @@ public class Aes256EncrypterTest {
 		final StringBuilder password = new StringBuilder("test123");
 		encrypter = new Aes256Encrypter(password);
 		
-		// Encrypt same plaintext multiple times
 		final String plaintext = "Hello World";
 		final String encrypted1 = encrypter.encrypt(plaintext);
 		final String encrypted2 = encrypter.encrypt(plaintext);
 		final String encrypted3 = encrypter.encrypt(plaintext);
 		
-		// All should be different
-		assertNotEquals(encrypted1, encrypted2);
-		assertNotEquals(encrypted2, encrypted3);
-		assertNotEquals(encrypted1, encrypted3);
+		assertThat(encrypted1).isNotEqualTo(encrypted2);
+		assertThat(encrypted2).isNotEqualTo(encrypted3);
+		assertThat(encrypted1).isNotEqualTo(encrypted3);
 		
-		// But all should decrypt to the same plaintext
-		assertThat(encrypter.decrypt(encrypted1), equalTo(plaintext));
-		assertThat(encrypter.decrypt(encrypted2), equalTo(plaintext));
-		assertThat(encrypter.decrypt(encrypted3), equalTo(plaintext));
+		assertThat(encrypter.decrypt(encrypted1)).isEqualTo(plaintext);
+		assertThat(encrypter.decrypt(encrypted2)).isEqualTo(plaintext);
+		assertThat(encrypter.decrypt(encrypted3)).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -103,7 +86,7 @@ public class Aes256EncrypterTest {
 		final String encrypted = encrypter.encrypt(plaintext);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, equalTo(plaintext));
+		assertThat(decrypted).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -115,7 +98,7 @@ public class Aes256EncrypterTest {
 		final String encrypted = encrypter.encrypt(plaintext);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, equalTo(plaintext));
+		assertThat(decrypted).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -131,7 +114,7 @@ public class Aes256EncrypterTest {
 		final String encrypted = encrypter.encrypt(plaintext);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, equalTo(plaintext));
+		assertThat(decrypted).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -139,7 +122,6 @@ public class Aes256EncrypterTest {
 		final StringBuilder password = new StringBuilder("password");
 		encrypter = new Aes256Encrypter(password);
 		
-		// Create string with all ASCII printable characters
 		final StringBuilder sb = new StringBuilder();
 		for (int i = 32; i < 127; i++) {
 			sb.append((char) i);
@@ -148,7 +130,7 @@ public class Aes256EncrypterTest {
 		final String encrypted = encrypter.encrypt(plaintext);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, equalTo(plaintext));
+		assertThat(decrypted).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -160,7 +142,7 @@ public class Aes256EncrypterTest {
 		final String encrypted = encrypter.encrypt(plaintext);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, equalTo(plaintext));
+		assertThat(decrypted).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -172,7 +154,7 @@ public class Aes256EncrypterTest {
 		final String encrypted = encrypter.encrypt(plaintext);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, equalTo(plaintext));
+		assertThat(decrypted).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -184,7 +166,7 @@ public class Aes256EncrypterTest {
 		final String encrypted = encrypter.encrypt(plaintext);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, equalTo(plaintext));
+		assertThat(decrypted).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -196,7 +178,7 @@ public class Aes256EncrypterTest {
 		final String encrypted = encrypter.encrypt(plaintext);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, equalTo(plaintext));
+		assertThat(decrypted).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -211,7 +193,7 @@ public class Aes256EncrypterTest {
 		final String encrypted = encrypter.encrypt(plaintext);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, equalTo(plaintext));
+		assertThat(decrypted).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -223,7 +205,7 @@ public class Aes256EncrypterTest {
 		final String encrypted = encrypter.encrypt(plaintext);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, equalTo(plaintext));
+		assertThat(decrypted).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -235,7 +217,7 @@ public class Aes256EncrypterTest {
 		final String encrypted = encrypter.encrypt(plaintext);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, equalTo(plaintext));
+		assertThat(decrypted).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -247,7 +229,7 @@ public class Aes256EncrypterTest {
 		final String encrypted = encrypter.encrypt(plaintext);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, equalTo(plaintext));
+		assertThat(decrypted).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -261,7 +243,7 @@ public class Aes256EncrypterTest {
 		encrypter = new Aes256Encrypter(password2);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, nullValue());
+		assertThat(decrypted).isNull();
 	}
 
 	@Test
@@ -271,11 +253,11 @@ public class Aes256EncrypterTest {
 		final String encrypted = encrypter1.encrypt("secret");
 		encrypter1.destroy();
 		
-		final StringBuilder password2 = new StringBuilder("Password");  // Different case
+		final StringBuilder password2 = new StringBuilder("Password");
 		encrypter = new Aes256Encrypter(password2);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, nullValue());
+		assertThat(decrypted).isNull();
 	}
 
 	@Test
@@ -289,7 +271,7 @@ public class Aes256EncrypterTest {
 		encrypter = new Aes256Encrypter(password2);
 		final String decrypted = encrypter.decrypt(encrypted);
 		
-		assertThat(decrypted, nullValue());
+		assertThat(decrypted).isNull();
 	}
 
 	@Test
@@ -320,7 +302,7 @@ public class Aes256EncrypterTest {
 		encrypter = new Aes256Encrypter(password);
 		
 		final String decrypted = encrypter.decrypt(null);
-		assertThat(decrypted, nullValue());
+		assertThat(decrypted).isNull();
 	}
 
 	@Test
@@ -329,7 +311,7 @@ public class Aes256EncrypterTest {
 		encrypter = new Aes256Encrypter(password);
 		
 		final String decrypted = encrypter.decrypt("");
-		assertThat(decrypted, nullValue());
+		assertThat(decrypted).isNull();
 	}
 
 	@Test
@@ -338,7 +320,7 @@ public class Aes256EncrypterTest {
 		encrypter = new Aes256Encrypter(password);
 		
 		final String decrypted = encrypter.decrypt("FP-AES256-V1:not-valid-base64!@#$");
-		assertThat(decrypted, nullValue());
+		assertThat(decrypted).isNull();
 	}
 
 	@Test
@@ -347,11 +329,10 @@ public class Aes256EncrypterTest {
 		encrypter = new Aes256Encrypter(password);
 		
 		final String encrypted = encrypter.encrypt("test");
-		// Truncate the encrypted string
 		final String truncated = encrypted.substring(0, encrypted.length() / 2);
 		final String decrypted = encrypter.decrypt(truncated);
 		
-		assertThat(decrypted, nullValue());
+		assertThat(decrypted).isNull();
 	}
 
 	@Test
@@ -366,7 +347,7 @@ public class Aes256EncrypterTest {
 		final String decrypted = encrypter2.decrypt(encrypted);
 		encrypter2.destroy();
 		
-		assertThat(decrypted, equalTo(plaintext));
+		assertThat(decrypted).isEqualTo(plaintext);
 	}
 
 	@Test
@@ -378,7 +359,7 @@ public class Aes256EncrypterTest {
 			final String plaintext = "Message " + i;
 			final String encrypted = encrypter.encrypt(plaintext);
 			final String decrypted = encrypter.decrypt(encrypted);
-			assertThat(decrypted, equalTo(plaintext));
+			assertThat(decrypted).isEqualTo(plaintext);
 		}
 	}
 
@@ -390,8 +371,8 @@ public class Aes256EncrypterTest {
 		final String plaintext = "This is secret";
 		final String encrypted = encrypter.encrypt(plaintext);
 		
-		assertThat(encrypted, not(equalTo(plaintext)));
-		assertThat(encrypted.contains("This is secret"), equalTo(false));
+		assertThat(encrypted).isNotEqualTo(plaintext);
+		assertThat(encrypted).doesNotContain("This is secret");
 	}
 
 	@Test
@@ -402,7 +383,7 @@ public class Aes256EncrypterTest {
 		final String plaintext = "Hi";
 		final String encrypted = encrypter.encrypt(plaintext);
 		
-		assertTrue("Encrypted content should be longer", encrypted.length() > plaintext.length());
+		assertThat(encrypted.length()).isGreaterThan(plaintext.length());
 	}
 
 	@Test
@@ -413,17 +394,14 @@ public class Aes256EncrypterTest {
 		final String plaintext = "test";
 		final String encrypted = encrypter.encrypt(plaintext);
 		
-		assertTrue("Encrypted content should start with prefix", 
-			encrypted.startsWith(EncryptionHeader.PREFIX_AES256));
+		assertThat(encrypted).startsWith(EncryptionHeader.PREFIX_AES256);
 		
 		String base64Data = EncryptionHeader.stripPrefix(encrypted);
-		assertThat("Should have base64 data after prefix", base64Data, notNullValue());
+		assertThat(base64Data).isNotNull();
 		
 		final byte[] decoded = DesEncrypter.fromBase64(base64Data);
 		
-		// Format: 16-byte salt + 16-byte IV + ciphertext
-		assertTrue("Encrypted content should have salt + IV + ciphertext", 
-			decoded.length >= 48);
+		assertThat(decoded.length).isGreaterThanOrEqualTo(44);
 	}
 
 	@Test
@@ -433,8 +411,7 @@ public class Aes256EncrypterTest {
 		
 		final String encrypted = encrypter.encrypt("test");
 		
-		assertTrue("Encryption should use prefix",
-			encrypted.startsWith("FP-AES256-V1:"));
+		assertThat(encrypted).startsWith("FP-AES256-V1:");
 	}
 }
 


### PR DESCRIPTION
AES-CBC occasionally decrypts with wrong password when garbage output has valid-looking padding (~1/256 chance). GCM provides authenticated encryption that always fails with AEADBadTagException on wrong password.

Changes:
- IV: From 16 to 12 bytes (GCM standard)
- Cipher: From AES/CBC/PKCS5Padding to AES/GCM/NoPadding
- Spec: From IvParameterSpec to GCMParameterSpec(128)

No compatibility impact - feature added Nov 23, not yet in stable release.
Important: Note that maps created with the version in between cannot be opened with the newer code

I now use AssertJ  instead of hamcrest

did a full gradle test and encryption test. Everything passed. Also did manual tests.