### PR TITLE
Fix Security Vulnerabilities and Improve Encryption Code

### DIFF
--- a/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionController.java
+++ b/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionController.java
@@ -153,17 +153,18 @@ public class EncryptionController implements IExtension {
         final String encryptedContent = encryptionModel.getEncryptedContent();
         final IEncrypter tempEncrypter = EncryptionHelper.createDecrypter(password, encryptedContent);
 
-        boolean decrypted = encryptionModel.decrypt(mapController, tempEncrypter);
+        try {
+            boolean decrypted = encryptionModel.decrypt(mapController, tempEncrypter);
 
-        if (decrypted) {
-            final IEncrypter aesEncrypter = EncryptionHelper.createEncrypter(password);
-            encryptionModel.setEncrypter(aesEncrypter);
-            tempEncrypter.destroy();
-        } else {
+            if (decrypted) {
+                final IEncrypter aesEncrypter = EncryptionHelper.createEncrypter(password);
+                encryptionModel.setEncrypter(aesEncrypter);
+            }
+
+            return decrypted;
+        } finally {
             tempEncrypter.destroy();
         }
-
-        return decrypted;
     }
 
 	private void encrypt(final NodeModel node, PasswordStrategy passwordStrategy) {

--- a/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionController.java
+++ b/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionController.java
@@ -139,12 +139,19 @@ public class EncryptionController implements IExtension {
 		final StringBuilder password = passwordStrategy.getPassword(node);
 		if (passwordStrategy.isCancelled())
 			return false;
-		if (!decrypt(encryptionModel, password)) {
-			passwordStrategy.onWrongPassword();
-			return false;
-		}
-		else {
-			return true;
+		
+		try {
+			if (!decrypt(encryptionModel, password)) {
+				passwordStrategy.onWrongPassword();
+				return false;
+			}
+			else {
+				return true;
+			}
+		} finally {
+			if (password != null) {
+				password.setLength(0);
+			}
 		}
 	}
 
@@ -198,38 +205,45 @@ public class EncryptionController implements IExtension {
 		if (passwordStrategy.isCancelled()) {
 			return;
 		}
-		final IEncrypter encrypter = EncryptionHelper.createEncrypter(password);
-		final EncryptionModel encryptionModel;
+		
 		try {
-			encryptionModel = new EncryptionModel(node, encrypter);
-		} catch (Exception e) {
-			encrypter.destroy();
-			throw e;
+			final IEncrypter encrypter = EncryptionHelper.createEncrypter(password);
+			final EncryptionModel encryptionModel;
+			try {
+				encryptionModel = new EncryptionModel(node, encrypter);
+			} catch (Exception e) {
+				encrypter.destroy();
+				throw e;
+			}
+			final IActor actor = new IActor() {
+				@Override
+				public void act() {
+					node.addExtension(encryptionModel);
+					fireEncryptionChangedEvent();
+				}
+
+				@Override
+				public String getDescription() {
+					return "encrypt";
+				}
+
+				@Override
+				public void undo() {
+					node.removeExtension(encryptionModel);
+					fireEncryptionChangedEvent();
+				}
+
+				private void fireEncryptionChangedEvent() {
+					Controller.getCurrentModeController().getMapController().mapSaved(node.getMap(), false);
+					EncryptionController.this.fireEncryptionChangedEvent(node);
+				}
+			};
+			Controller.getCurrentModeController().execute(actor, node.getMap());
+		} finally {
+			if (password != null) {
+				password.setLength(0);
+			}
 		}
-		final IActor actor = new IActor() {
-			@Override
-			public void act() {
-				node.addExtension(encryptionModel);
-				fireEncryptionChangedEvent();
-			}
-
-			@Override
-			public String getDescription() {
-				return "encrypt";
-			}
-
-			@Override
-			public void undo() {
-				node.removeExtension(encryptionModel);
-				fireEncryptionChangedEvent();
-			}
-
-			private void fireEncryptionChangedEvent() {
-				Controller.getCurrentModeController().getMapController().mapSaved(node.getMap(), false);
-				EncryptionController.this.fireEncryptionChangedEvent(node);
-			}
-		};
-		Controller.getCurrentModeController().execute(actor, node.getMap());
 	}
 
 

--- a/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionController.java
+++ b/freeplane/src/main/java/org/freeplane/features/encrypt/EncryptionController.java
@@ -151,19 +151,40 @@ public class EncryptionController implements IExtension {
     private boolean decrypt(final EncryptionModel encryptionModel, final StringBuilder password) {
         final MapController mapController = Controller.getCurrentModeController().getMapController();
         final String encryptedContent = encryptionModel.getEncryptedContent();
-        final IEncrypter tempEncrypter = EncryptionHelper.createDecrypter(password, encryptedContent);
+        final IEncrypter encrypter = EncryptionHelper.createDecrypter(password, encryptedContent);
 
+        boolean encrypterOwnershipTransferred = false;
         try {
-            boolean decrypted = encryptionModel.decrypt(mapController, tempEncrypter);
+            boolean decrypted = encryptionModel.decrypt(mapController, encrypter);
 
             if (decrypted) {
-                final IEncrypter aesEncrypter = EncryptionHelper.createEncrypter(password);
-                encryptionModel.setEncrypter(aesEncrypter);
+                if (encrypter instanceof Aes256Encrypter) {
+                    transferEncrypterOwnership(encryptionModel, encrypter);
+                    encrypterOwnershipTransferred = true;
+                } else {
+                    upgradeFromLegacyDesToAes256(encryptionModel, password);
+                }
             }
 
             return decrypted;
         } finally {
-            tempEncrypter.destroy();
+            if (!encrypterOwnershipTransferred) {
+                encrypter.destroy();
+            }
+        }
+    }
+
+    private void transferEncrypterOwnership(final EncryptionModel encryptionModel, final IEncrypter encrypter) {
+        encryptionModel.setEncrypter(encrypter);
+    }
+
+    private void upgradeFromLegacyDesToAes256(final EncryptionModel encryptionModel, final StringBuilder password) {
+        final IEncrypter aes256Encrypter = EncryptionHelper.createEncrypter(password);
+        try {
+            encryptionModel.setEncrypter(aes256Encrypter);
+        } catch (Exception e) {
+            aes256Encrypter.destroy();
+            throw e;
         }
     }
 


### PR DESCRIPTION
Fix Security Vulnerabilities and Improve Encryption Code

 Security Fixes:

1. **Encrypter memory leak**: Added try-finally blocks to guarantee `encrypter.destroy()` 
   is called even when exceptions occur, preventing passwords/keys from lingering in memory.

2. **Password memory leak**: Added try-finally blocks to clear `StringBuilder password` 
   immediately after use via `password.setLength(0)`.

**Impact**: Without these fixes, cleartext passwords remain in memory indefinitely, 
vulnerable to memory dumps, swap file analysis, and cold boot attacks.


using `jmap -dump:format=b,file=freeplane_heap.bin`, I could easily find the password in cleartext for previous versions of Freeplane. The following demo shows it was trivial to just dump memory to fetch my hidden password (I literally used password "hiddenpassword" in the example below). This vulnerability applies to any older version of Freeplane.

<img width="605" height="498" alt="Screenshot from 2025-11-29 21-24-06" src="https://github.com/user-attachments/assets/6320bffd-a7e5-4aed-9f99-5b311e65e798" />



Bug fix:

3. **Unnecessary re-encryption**: Fixed bug where AES-256 encrypted nodes were needlessly 
   re-encrypted. Now only upgrades legacy DES encryption.

Code quality:
 
4. **Improved clarity**: Extracted `transferEncrypterOwnership()` and 
   `upgradeFromLegacyDesToAes256()` methods with explicit ownership tracking.
   
  
Tests conducted:

- Manual tests (decryption of legacy and new map)
- 107 encryption tests passed

