### PR TITLE
Issue #2772: fix jumped-in view-root inconsistencies after restart

### DIFF
--- a/freeplane/src/main/java/org/freeplane/view/swing/map/MapView.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/MapView.java
@@ -3348,6 +3348,8 @@ public class MapView extends JPanel implements Printable, Autoscroll, IMapChange
 		}
 		else
 		    rootsHistory.clear();
+		if(! newRootView.getNode().getViewers().contains(newRootView))
+		    newRootView.getNode().addViewer(newRootView);
 		if(nextSelectedNode.getParent() == null || ! nextSelectedNode.isContentVisible())
 		    nextSelectedNode = newRootView;
 		if(newRootView.getComponentCount() == 1) {

--- a/freeplane/src/main/java/org/freeplane/view/swing/map/MapView.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/MapView.java
@@ -3206,6 +3206,10 @@ public class MapView extends JPanel implements Printable, Autoscroll, IMapChange
 		if(currentRootNode == node)
 			return;
 		modeController.getMapController().setFolded(node, false, getFilter());
+		for(NodeModel ancestor = node.getParentNode(); ancestor != null; ancestor = ancestor.getParentNode()) {
+			if(ancestor.isFolded())
+				modeController.getMapController().setFolded(ancestor, false, getFilter());
+		}
         NodeView nodeView = getNodeView(node);
         RootChange rootChange;
         if(nodeView == null) {

--- a/freeplane/src/main/java/org/freeplane/view/swing/map/MapView.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/MapView.java
@@ -3205,6 +3205,7 @@ public class MapView extends JPanel implements Printable, Autoscroll, IMapChange
 		NodeModel currentRootNode = currentRootView.getNode();
 		if(currentRootNode == node)
 			return;
+		modeController.getMapController().setFolded(node, false, getFilter());
         NodeView nodeView = getNodeView(node);
         RootChange rootChange;
         if(nodeView == null) {

--- a/freeplane/src/test/java/org/freeplane/view/swing/map/MapViewRootChangeTest.java
+++ b/freeplane/src/test/java/org/freeplane/view/swing/map/MapViewRootChangeTest.java
@@ -61,6 +61,22 @@ public class MapViewRootChangeTest {
         });
     }
 
+    @Test
+    public void setRootNodeUnfoldsFoldedAncestors() {
+        withMapView((view, target) -> {
+            final NodeModel bbb = target.getParentNode();
+            final NodeModel aaa = bbb.getParentNode();
+            target.setFolded(true);
+            bbb.setFolded(true);
+            aaa.setFolded(true);
+
+            view.setRootNode(target);
+
+            assertThat(bbb.isFolded(), equalTo(false));
+            assertThat(aaa.isFolded(), equalTo(false));
+        });
+    }
+
     private interface MapViewScenario {
         void run(MapView view, NodeModel target);
     }
@@ -123,8 +139,12 @@ public class MapViewRootChangeTest {
             }).when(mapController).setFolded(any(), anyBoolean(), any());
 
             MapFake mapFake = new MapFake();
+            NodeModel aaa = mapFake.createNode("aaa");
+            NodeModel bbb = mapFake.createNode("bbb");
             NodeModel target = mapFake.createNode("target");
-            mapFake.getRoot().insert(target);
+            mapFake.getRoot().insert(aaa);
+            aaa.insert(bbb);
+            bbb.insert(target);
             MapModel map = mapFake.getRoot().getMap();
             MapStyleModel mapStyleModel = mock(MapStyleModel.class, RETURNS_DEEP_STUBS);
             when(mapStyleModel.getZoom()).thenReturn(1f);

--- a/freeplane/src/test/java/org/freeplane/view/swing/map/MapViewRootChangeTest.java
+++ b/freeplane/src/test/java/org/freeplane/view/swing/map/MapViewRootChangeTest.java
@@ -1,0 +1,142 @@
+package org.freeplane.view.swing.map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.freeplane.api.HorizontalTextAlignment;
+import org.freeplane.core.extension.IExtension;
+import org.freeplane.core.resources.ResourceBundles;
+import org.freeplane.core.resources.ResourceController;
+import org.freeplane.core.util.Compat;
+import org.freeplane.features.map.MapController;
+import org.freeplane.features.map.MapFake;
+import org.freeplane.features.map.MapModel;
+import org.freeplane.features.map.NodeModel;
+import org.freeplane.features.mode.Controller;
+import org.freeplane.features.mode.ModeController;
+import org.freeplane.features.nodestyle.NodeGeometryModel;
+import org.freeplane.features.nodestyle.NodeStyleController;
+import org.freeplane.features.nodestyle.NodeStyleShape;
+import org.freeplane.features.styles.MapStyle;
+import org.freeplane.features.styles.MapStyleModel;
+import org.freeplane.features.styles.MapViewLayout;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+public class MapViewRootChangeTest {
+
+    @Test
+    public void setRootNodeUnfoldsNodeInModel() {
+        withMapView((view, target) -> {
+            target.setFolded(true);
+
+            view.setRootNode(target);
+
+            assertThat(target.isFolded(), equalTo(false));
+        });
+    }
+
+    @Test
+    public void setRootNodeKeepsAlreadyUnfoldedNode() {
+        withMapView((view, target) -> {
+            target.setFolded(false);
+
+            view.setRootNode(target);
+
+            assertThat(target.isFolded(), equalTo(false));
+        });
+    }
+
+    private interface MapViewScenario {
+        void run(MapView view, NodeModel target);
+    }
+
+    private void withMapView(MapViewScenario scenario) {
+        Compat.setIsApplet(false);
+        ResourceController resourceController = mock(ResourceController.class);
+        when(resourceController.getProperty(anyString())).thenAnswer(invocation ->
+                ((String) invocation.getArgument(0)).toLowerCase().contains("color") ? "#ff000000" : "false");
+        when(resourceController.getProperty(anyString(), anyString())).thenAnswer(invocation -> invocation.getArgument(1));
+        when(resourceController.getBooleanProperty(anyString())).thenReturn(false);
+        when(resourceController.getIntProperty(anyString(), anyInt())).thenAnswer(invocation -> invocation.getArgument(1));
+        when(resourceController.getIntProperty(anyString())).thenReturn(0);
+        when(resourceController.getColorProperty(anyString())).thenReturn(Color.BLACK);
+        when(resourceController.getLengthProperty(anyString())).thenReturn(0);
+        when(resourceController.getDoubleProperty(anyString(), anyInt())).thenAnswer(invocation -> (double) (int) invocation.getArgument(1));
+        when(resourceController.getArrayProperty(anyString(), anyString())).thenReturn(new String[0]);
+        when(resourceController.getFreeplaneUserDirectory()).thenReturn(System.getProperty("java.io.tmpdir"));
+        when(resourceController.getLengthQuantityProperty(anyString()))
+                .thenReturn(new org.freeplane.api.Quantity<>(16, org.freeplane.api.LengthUnit.px));
+        when(resourceController.getResource(anyString()))
+                .thenAnswer(invocation -> MapViewRootChangeTest.class.getResource(invocation.getArgument(0)));
+        try {
+            when(resourceController.getResourceStream(anyString()))
+                    .thenAnswer(invocation -> MapViewRootChangeTest.class.getResourceAsStream(invocation.getArgument(0)));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        ResourceBundles resourceBundles = mock(ResourceBundles.class);
+        when(resourceBundles.getResourceString(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(resourceBundles.getResourceString(anyString(), anyString())).thenAnswer(invocation -> invocation.getArgument(1));
+        when(resourceController.getResources()).thenReturn(resourceBundles);
+
+        try (MockedStatic<ResourceController> resourceControllers = mockStatic(ResourceController.class)) {
+            resourceControllers.when(ResourceController::getResourceController).thenReturn(resourceController);
+
+            ModeController modeController = mock(ModeController.class, RETURNS_DEEP_STUBS);
+            Controller controller = mock(Controller.class, RETURNS_DEEP_STUBS);
+            when(controller.getModeController()).thenReturn(modeController);
+            Controller.setCurrentController(controller);
+
+            Map<Class<?>, Object> extensions = new HashMap<>();
+            NodeStyleController nodeStyleController = mock(NodeStyleController.class);
+            when(nodeStyleController.getFont(any(), any())).thenReturn(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
+            when(nodeStyleController.getHorizontalTextAlignment(any(), any())).thenReturn(HorizontalTextAlignment.DEFAULT);
+            when(nodeStyleController.getShapeConfiguration(any(), any())).thenReturn(NodeGeometryModel.FORK);
+            when(nodeStyleController.getShape(any(), any())).thenReturn(NodeStyleShape.fork);
+            extensions.put(NodeStyleController.class, nodeStyleController);
+            MapStyle mapStyle = mock(MapStyle.class);
+            when(mapStyle.getBackground(any())).thenReturn(Color.WHITE);
+            extensions.put(MapStyle.class, mapStyle);
+            when(modeController.getExtension(org.mockito.ArgumentMatchers.<Class<IExtension>>any()))
+                    .thenAnswer(invocation -> extensions.computeIfAbsent(invocation.getArgument(0), c -> mock((Class<?>) c)));
+
+            MapController mapController = modeController.getMapController();
+            doAnswer(invocation -> {
+                NodeModel node = invocation.getArgument(0);
+                node.setFolded(invocation.getArgument(1));
+                return null;
+            }).when(mapController).setFolded(any(), anyBoolean(), any());
+
+            MapFake mapFake = new MapFake();
+            NodeModel target = mapFake.createNode("target");
+            mapFake.getRoot().insert(target);
+            MapModel map = mapFake.getRoot().getMap();
+            MapStyleModel mapStyleModel = mock(MapStyleModel.class, RETURNS_DEEP_STUBS);
+            when(mapStyleModel.getZoom()).thenReturn(1f);
+            when(mapStyleModel.getMapViewLayout()).thenReturn(MapViewLayout.MAP);
+            when(map.getExtension(MapStyleModel.class)).thenReturn(mapStyleModel);
+
+            MapView view = new MapView(map, modeController);
+
+            scenario.run(view, target);
+        }
+        finally {
+            Controller.setCurrentController(null);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2772.

This addresses three related defects that all stem from the same
situation: after a restart restores a jumped-in view root whose
ancestors are folded (`load_folding=always_fold_all_after_load`), the
restored state is internally inconsistent. Each is a separate atomic
commit, so parts can be taken independently.

## 1. Folded model state when a node becomes the view root

On restore, `lastRoots` says "you were inside ccc" while `foldAll` says
"ccc is folded in the model". Nothing reconciles them: the view root is
displayed expanded and cannot be folded while it is the root, yet
`NodeModel.folded` stays `true`. On jump out the model wins — any
`NodeView` rebuilt for the node initializes folded from the stale model
state (`NodeView.java:387`), so the node the user was just inside comes
back collapsed. Full trace in [the diagnosis comment](https://github.com/freeplane/freeplane/issues/2772#issuecomment-4991397801).

Change: in `MapView.setRootNode(NodeModel)`, unfold the node in the
model when it becomes the view root, routing through
`MapController.setFolded` so regular folding events fire.

Declared behavior consequences (a maintainer design call): with
`save_folding` in `{always, if_map_is_changed}` the unfold becomes an
undoable actor at startup (read-only — the `.mm` hash stays unchanged,
verified); and jumping into an explicitly folded node now unfolds it in
the model.

## 2. Selection lost on jump out

The first fix unfolds only the node, not its ancestors, so after the
restore there is still no `NodeView` for it (the ancestors are folded):
it is created as an orphan root view, and on jump out the orphan is
discarded and the selection falls back to the map root — the user loses
the context they were restored into.

Change: also unfold the folded ancestors in
`MapView.setRootNode(NodeModel)`, so the restored subtree materializes
real `NodeView`s and the selection survives jump out.

## 3. Invisible child created on a jumped-in view root

Creating a child on a jumped-in view root produced a child that only
appeared after jump out. Cause: the root swap tears down the old root
subtree with `NodeView.remove()`, which recurses into child views; when
the node being jumped into was a child of the old root, that recursion
deregisters its `NodeView` as a viewer of its `NodeModel`, and nothing
re-registers it. So `NodeModel.fireNodeInserted` never reaches the map
root view, and the inserted child gets no view until a later jump out
rebuilds the subtree.

Change: re-register the current root view as a viewer of its node after
the swap in `MapView.setRootNode(NodeView, RootChange)`, guarded so a
node that is already a viewer is not added twice.

## Verification

- `MapViewRootChangeTest` builds a real `MapView` under mocks: the
  fold-state regression case (#1) and the ancestor-unfold regression
  case (#2) both fail on `1.13.x` without the change and pass with it.
- Defect #3 has no automated regression: reproducing it needs a node
  that already has a built child view before becoming the view root,
  which the headless test harness cannot set up (child-view creation is
  deferred until the map is displayable). Verified manually with a
  deterministic reproducer (open a restored jump-in on a node, jump in,
  Insert a child — with the fix it appears immediately).
- The deterministic reproducer from the issue, run A/B on this branch's
  base, confirms #1 and #2 in the GUI; the full `:freeplane:test` suite
  passes.
