### PR TITLE
Keep the selection on jump out after a restart restores a jumped-in view root

### DIFF
--- a/freeplane/src/main/java/org/freeplane/main/application/LastOpenedList.java
+++ b/freeplane/src/main/java/org/freeplane/main/application/LastOpenedList.java
@@ -183,8 +183,13 @@ public class LastOpenedList implements IMapViewChangeListener, IMapChangeListene
 			if (selection.isSelected(map.getRootNode())) {
 				if(recentFile.lastRootNodeId !=  null) {
 					final NodeModel root = map.getNodeForID(recentFile.lastRootNodeId);
-					if(root != null)
+					if(root != null) {
+						final MapController mapController = controller.getModeController().getMapController();
+						for(NodeModel ancestor = root.getParentNode(); ancestor != null; ancestor = ancestor.getParentNode())
+							if(mapController.isFolded(ancestor))
+								mapController.setFolded(ancestor, false, selection.getFilter());
 						controller.getMapViewManager().setViewRoot(root);
+					}
 				}
 				final NodeModel node = map.getNodeForID(recentFile.lastVisitedNodeId);
 				if (node != null && node.hasVisibleContent(selection.getFilter())) {


### PR DESCRIPTION

Fixes 2940.

## What happens

After a restart restores a jumped-in view root whose ancestors are folded (for example with `load_folding=always_fold_all_after_load`, or with the path saved folded in the file), jumping out drops the selection to the map root instead of the node the user was restored into.

`LastOpenedList` restores the view root through `IMapViewManager.setViewRoot`. Because the ancestors are folded, no `NodeView` exists for the node, so it is built as an orphan root view (no parent view). On jump out, `MapView.restoreRootNode` discards that orphan, and the `JUMP_OUT` selection fallback in `setRootNode` reassigns the selection to the map root.

## Change

In `LastOpenedList.selectLastVisitedNode`, when a jumped-in view root is restored, unfold its folded ancestors in the model (through `MapController.setFolded`, so normal folding events fire) before setting the view root. The restored subtree then materializes real `NodeView`s, the node is no longer an orphan root, and the selection survives jump out.

Two deliberate scoping choices:

- Only the ancestors are unfolded — the node's own fold state is left untouched. A node that was folded comes back folded after jump out, which is its expected state; this fix is only about the path to it being open enough that it stays selected.
- The unfold is applied only on this restore path, not in the general `setViewRoot`, so other ways of opening a node as the view root are unaffected. In particular, "open as root" bookmarks keep their folding: they are meant for navigating isolated parts of a map, where jumping out of a bookmarked node behaving as before is the expected behavior.

## Verification

- Verified manually with a deterministic reproducer (restore a jumped-in node with a folded path, jump out): the node stays selected, and the bookmark path is confirmed unaffected (jumping into a folded node via an "open as root" bookmark leaves its ancestors folded).
- No automated regression: the change lives in the startup restore path, which the headless test harness does not exercise.
- The `:freeplane:test` suite passes.
