### PR TITLE
Keep the view root registered as a viewer of its node

### DIFF
--- a/freeplane/src/main/java/org/freeplane/view/swing/map/MapView.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/MapView.java
@@ -3343,6 +3343,8 @@ public class MapView extends JPanel implements Printable, Autoscroll, IMapChange
 		}
 		else
 		    rootsHistory.clear();
+		if(! newRootView.getNode().getViewers().contains(newRootView))
+		    newRootView.getNode().addViewer(newRootView);
 		if(nextSelectedNode.getParent() == null || ! nextSelectedNode.isContentVisible())
 		    nextSelectedNode = newRootView;
 		if(newRootView.getComponentCount() == 1) {


### PR DESCRIPTION

Fixes 2941.

## What happens

When a child is created on a node that is the jumped-in view root, the child is added to the model but no view is drawn for it; it appears only after a later jump out.

When a node becomes the view root, the root swap tears down the old root subtree with `NodeView.remove()`, which recurses into child views. If the node being jumped into was a child of the old root, that recursion deregisters its `NodeView` as a viewer of its `NodeModel`, and nothing re-registers it. So while the node is the view root, `NodeModel.fireNodeInserted` — which iterates the node's viewers — never reaches the map root view (only the outline's viewer remains). The inserted child updates the model but gets no view until a later jump out rebuilds the subtree.

## Change

Re-register the current root view as a viewer of its node after the swap in `MapView.setRootNode(NodeView, RootChange)`, guarded with `getViewers().contains` so a node that is already a viewer is not added twice.

## Verification

- No automated regression: reproducing it needs the reuse jump-in path (a node with an already-built child view before becoming the view root), which the headless test harness cannot set up because child-view creation is deferred until the map is displayable. The closest automated substitute would need a real displayable `MapView`.
- Verified manually with a deterministic reproducer: jump into a node that is the restored view root, create a child — with the change it appears immediately, and jump out stays consistent.
- The `:freeplane:test` suite passes.

Issue: https://github.com/freeplane/freeplane/issues/2941
