### PR TITLE
Honor "Fold on click inside" when double-click editing is disabled

### DIFF
--- a/freeplane/src/main/java/org/freeplane/view/swing/ui/DefaultNodeMouseMotionListener.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/ui/DefaultNodeMouseMotionListener.java
@@ -124,8 +124,8 @@ public class DefaultNodeMouseMotionListener implements IMouseListener {
             }
 
 			if(Compat.isPlainEvent(e)){
-				if(inside && (e.getClickCount() == 1 && foldsOnClickInside()
-				        || ! (mc.canEdit(node.getMap()) && editsOnDoubleClick()))){
+				if(inside && foldsOnClickInside()
+				        && (e.getClickCount() == 1 || ! (mc.canEdit(node.getMap()) && editsOnDoubleClick()))){
 					if (!nodeSelector.shouldSelectOnClick(e) && !nodeFolder.isPreviewUnfolded(node)) {
 					    isDelayedFoldingActive = true;
 						doubleClickTimer.start(new Runnable() {


### PR DESCRIPTION
# Honor "Fold on click inside" when double-click editing is disabled

Fixes #2935

## Symptom

A plain click inside a node toggles its folding even with **Fold on click inside** turned off, as long as **Edit on double click** is also off (or the map is not editable / in browse mode). Turning the setting off has no effect in those cases.

## Root cause

The guard in `DefaultNodeMouseMotionListener.mouseClicked` reads:

```java
if(inside && (e.getClickCount() == 1 && foldsOnClickInside()
        || ! (mc.canEdit(node.getMap()) && editsOnDoubleClick()))){
```

Because `&&` binds tighter than `||`, this parses as:

```java
inside && ( (clickCount==1 && foldsOnClickInside())  ||  !(canEdit && editsOnDoubleClick()) )
```

When `editsOnDoubleClick()` is `false` the second operand is `true`, so the whole condition is `true` regardless of `foldsOnClickInside()`. `editsOnDoubleClick()` is `false` whenever `edit_on_double_click` is off (or in the base listener used for non-editable maps), so in those configurations the setting is ignored.

## Fix

Make `foldsOnClickInside()` a required conjunct; the click-count / double-click-edit test stays as a secondary guard:

```java
if(inside && foldsOnClickInside()
        && (e.getClickCount() == 1 || ! (mc.canEdit(node.getMap()) && editsOnDoubleClick()))){
```

When the setting is on, this is equivalent to the original (same click-count and double-click-edit logic). When the setting is off, folding on click no longer happens — which is what the option name promises. The two differ only in the previously affected case.

## Verification

A/B between two builds (1.13.x as-is vs. this fix), exercising the real listener with the same click on the same node and profile:

| `edit_on_double_click` | `fold_on_click_inside` | before | after |
|---|---|---|---|
| on  | off | no fold | no fold |
| off | off | **folds (bug)** | **no fold** |
| off | on  | folds | folds |

The affected row now honors the setting, and the "setting on" row still folds, so folding-on-click is preserved when it is enabled. Confirmed with a manual click as well.
