### PR TITLE
Do not let the inline editor border widen the node (#2785)

### DIFF
--- a/freeplane/src/main/java/org/freeplane/view/swing/map/mindmapmode/EditNodeTextField.java
+++ b/freeplane/src/main/java/org/freeplane/view/swing/map/mindmapmode/EditNodeTextField.java
@@ -211,6 +211,8 @@ public class EditNodeTextField extends EditNodeBase {
 
 	}
 
+	private static final int TEXT_FIELD_BORDER_WIDTH = 2;
+
 	private int extraWidth;
 	final private boolean layoutMapOnTextChange;
 
@@ -311,7 +313,7 @@ public class EditNodeTextField extends EditNodeBase {
 		}
 
 	    final HTMLDocument document = (HTMLDocument) textfield.getDocument();
-	    document.getStyleSheet().addRule("body { width: " + maxWidth + "}");
+	    document.getStyleSheet().addRule("body { width: " + (maxWidth - 2 * TEXT_FIELD_BORDER_WIDTH) + "}");
 	    // bad hack: call "setEditable" only to update view
 	    textfield.setEditable(false);
 	    textfield.setEditable(true);
@@ -875,7 +877,7 @@ public class EditNodeTextField extends EditNodeBase {
 		SpellCheckerController.getController().enableAutoSpell(textfield, true);
 		mapView.scrollNodeToVisible(nodeView);
 		assert( parent.isValid());
-		final int textFieldBorderWidth = 2;
+		final int textFieldBorderWidth = TEXT_FIELD_BORDER_WIDTH;
 		textfield.setBorder(new MatteBorder(textFieldBorderWidth, textFieldBorderWidth, textFieldBorderWidth, textFieldBorderWidth,
 				MapView.drawsRectangleForSelection() ? MapView.getSelectionRectangleColor() : nodeView.getTextBackground()));
 		final Dimension textFieldMinimumSize = textfield.getPreferredSize();
@@ -914,10 +916,15 @@ public class EditNodeTextField extends EditNodeBase {
 		int textFieldX = Math.max(0, textR.x  - textFieldBorderWidth);
 		int textFieldY = Math.max(0, textR.y  - textFieldBorderWidth);
         verticalSpace = Math.max(textFieldY, parent.getHeight() - textFieldMinimumSize.height);
-		final Dimension newParentSize = new Dimension(textFieldX + textFieldMinimumSize.width + parentInsets.right,
+		final int editorBorderSpace = 2 * textFieldBorderWidth;
+		final Dimension newParentSize = new Dimension(
+				Math.max(parent.getWidth(), textFieldX + textFieldMinimumSize.width + parentInsets.right - editorBorderSpace),
 				verticalSpace + textFieldMinimumSize.height);
 		if (parent.getEffectiveHorizontalTextPosition() == SwingConstants.LEFT)
 			newParentSize.width += reservedIconSpace;
+		if (layoutMapOnTextChange)
+			textFieldMinimumSize.width = Math.min(textFieldMinimumSize.width,
+					newParentSize.width - textFieldX - parentInsets.right);
 		horizontalSpace = newParentSize.width - textFieldMinimumSize.width;
 		final Point location = new Point(textFieldX, textFieldY);
 
@@ -936,7 +943,7 @@ public class EditNodeTextField extends EditNodeBase {
 		}
 
         preserveRootNodeLocationOnScreen();
-		parent.preserveLayout(newParentSize);
+		parent.preserveLayout(layoutMapOnTextChange ? newParentSize : parent.getSize());
 		parent.setText("");
         mapView.onEditingStarted(parent);
         if(getEditControl().getEditType() == EditedComponent.TEXT)


### PR DESCRIPTION
Fixes the layout jump reported in #2785.

## Cause

The inline editor ends up a few pixels wider than the node it edits, and that width is what feeds the layout.

`EditNodeTextField.show()` sizes the text field from the label text area plus the border (`:912`, `textR.width + 2 * textFieldBorderWidth`), builds the new node size from it (`:917`) and freezes the node at that size (`:943`, `parent.preserveLayout(newParentSize)`). The `preserveLayout` call is needed because the next line clears the label text — without freezing, the node would shrink while the editor paints the text — so the intent there is to keep the node as it was; the value passed makes it grow instead.

The same happens on every keystroke when the map is laid out during editing: `layout()` (`:296`) sets the node preferred size from the field size, and the wrapping rule installed by `setLineWrap()` (`:315`) uses the full maximum width, so a wrapped text asks for maximum plus border.

In a compact layout that difference is enough to matter. On the reproducer of the issue the node is 426 px wide with 29 px of room before the column of the sibling's children; opening the editor makes it 433 px with 23 px, which no longer satisfies the horizontal gap, so the node is moved below the sibling subtree. The vertical gap goes from 0 to 252 px and disappears again when editing ends.

## Change

Three places, all aiming at the same thing: the node keeps the width it would have with the same text outside editing.

1. **`setLineWrap()`** — the CSS width used for wrapping subtracts the border, so a text that can wrap asks for exactly the maximum node width. A single word that cannot wrap still widens the node, as before, since its preferred width exceeds the maximum on its own.
2. **`show()`, node size** — the size built for `preserveLayout` no longer includes the border, and never falls below the current node width.
3. **`show()`, field size and `preserveLayout`** — when the map is laid out during editing the field is fitted into the space the node offers, instead of the node being grown to host the field; when it is not, the node simply keeps its current size, which is safe there because the field is added to the map view (`:954`) and can overlap the node without being clipped.

The node still grows in height while typing when the map is laid out during editing, which is what that option is for.

## Verification

Built from this branch and measured against a reproducer with a node of fixed width (`MIN_WIDTH = MAX_WIDTH = 10 cm`) fitted beside a taller sibling's subtree, with 29 px of horizontal room to spare.

Map laid out during editing **enabled**:

| | node | gap | editor |
|---|---|---|---|
| no editor | 426 × 38 | 0 | — |
| editor open | 426 × 38 | **0** | 420 px, ends 3 px inside the node |
| 50 characters typed, 3 lines | 426 × 104 | **0** | 420 px, ends inside |
| single long word | 562 × 71 | 339 | 558 px, ends inside |
| closed | 426 × 38 | 0 | — |

Map laid out during editing **disabled** (the default):

| | node | gap |
|---|---|---|
| editor open | 426 × 38 | **0** |
| 50 characters typed | 426 × 38 | **0** |

Before the change the same measurements gave 433 × 70 and a gap of 252 px on opening, and 431 px with a gap of 339 px while typing.

The single long word row is intentional: there the text cannot wrap, so the editor keeps growing and the node follows, as it did before this change.