### PR TITLE
Retain FlatLaf popup placement across monitors

### DIFF
--- a/freeplane/src/main/java/org/freeplane/core/util/Compat.java
+++ b/freeplane/src/main/java/org/freeplane/core/util/Compat.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import javax.swing.JFrame;
@@ -283,5 +284,22 @@ public class Compat {
 		}
 		else
 			Compat.isApplet = isApplet;
+	}
+
+	/**
+	 * Detects whether the current Java Virtual Machine is JetBrains Runtime (JBR).
+	 *
+	 * Checks java.vendor, java.vm.vendor, and java.vendor.version for presence of
+	 * "jetbrains" or "jbr" (case-insensitive).
+	 *
+	 * @return true if running under JetBrains Runtime, false otherwise
+	 */
+	public static boolean isJetBrainsRuntime() {
+		String vendor = System.getProperty("java.vendor", "");
+		String vmVendor = System.getProperty("java.vm.vendor", "");
+		String vendorVersion = System.getProperty("java.vendor.version", "");
+		return vendor.toLowerCase(Locale.ROOT).contains("jetbrains")
+			|| vmVendor.toLowerCase(Locale.ROOT).contains("jetbrains")
+			|| vendorVersion.toLowerCase(Locale.ROOT).contains("jbr");
 	}
 }

--- a/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
+++ b/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
@@ -702,7 +702,7 @@ abstract public class FrameController implements ViewController {
     private static void fixLookAndFeelUI(){
     	OSKeyBindingManager.applyToCurrentLookAndFeel();
     	configureFlatLookAndFeel();
-    	configurePopupFactory();
+		configurePopupFactory();
 		UIManager.put("Button.defaultButtonFollowsFocus", Boolean.TRUE);
 		UIManager.put("ComboBox.squareButton", Boolean.FALSE);
 		final ResourceController resourceController = ResourceController.getResourceController();

--- a/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
+++ b/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
@@ -102,6 +102,12 @@ import com.formdev.flatlaf.FlatLaf;
  * @author Dimitry Polivaev
  */
 abstract public class FrameController implements ViewController {
+	public static final String POPUP_FACTORY_PROPERTY = "freeplane.popup_factory";
+	public static final String POPUP_FACTORY_AUTO = "auto";
+	public static final String POPUP_FACTORY_FLATLAF = "flatlaf";
+	public static final String POPUP_FACTORY_BASIC = "basic";
+	public static final String FLAT_POPUP_FACTORY_CLASS = "com.formdev.flatlaf.ui.FlatPopupFactory";
+
 	public static final String VAQUA_LAF_NAME = "VAqua";
 	public static final String VAQUA_LAF_CLASS_NAME = "org.violetlib.aqua.AquaLookAndFeel";
     private static final String DARCULA_LAF_CLASS_NAME = "com.bulenkov.darcula.DarculaLaf";
@@ -665,8 +671,6 @@ abstract public class FrameController implements ViewController {
 						UIManager.setLookAndFeel((LookAndFeel) lookAndFeelClass.newInstance());
 						if (userLibClassLoader != uiClassLoader)
 							userLibClassLoader.close();
-						if(PopupFactory.getSharedInstance().getClass().getName().equals("com.formdev.flatlaf.ui.FlatPopupFactory"))
-							PopupFactory.setSharedInstance(basicPopupFactory);
 					}
 					catch (ClassNotFoundException | ClassCastException | InstantiationException e) {
 						LogUtils.warn("Error while setting Look&Feel " + lookAndFeel + ", reverted to default");
@@ -698,6 +702,7 @@ abstract public class FrameController implements ViewController {
     private static void fixLookAndFeelUI(){
     	OSKeyBindingManager.applyToCurrentLookAndFeel();
     	configureFlatLookAndFeel();
+    	configurePopupFactory();
 		UIManager.put("Button.defaultButtonFollowsFocus", Boolean.TRUE);
 		UIManager.put("ComboBox.squareButton", Boolean.FALSE);
 		final ResourceController resourceController = ResourceController.getResourceController();
@@ -732,6 +737,68 @@ abstract public class FrameController implements ViewController {
 		final Color color = UIManager.getColor("control");
 		if (color != null && color.getAlpha() < 255)
 			UIManager.getDefaults().put("control", Color.LIGHT_GRAY);
+	}
+
+	public static void configurePopupFactory() {
+		try {
+			if (Compat.isApplet()) {
+				return;
+			}
+		}
+		catch (IllegalStateException ex) {
+			// Compat.isApplet() throws IllegalStateException if not set (e.g. in standalone unit tests)
+		}
+
+		final ResourceController resourceController = ResourceController.getResourceController();
+		final String pref = (resourceController != null)
+			? resourceController.getProperty(POPUP_FACTORY_PROPERTY, POPUP_FACTORY_AUTO).trim().toLowerCase(java.util.Locale.ROOT)
+			: POPUP_FACTORY_AUTO;
+
+		final boolean isFlatLaf = UIManager.getLookAndFeel() instanceof FlatLaf;
+
+		if (POPUP_FACTORY_BASIC.equals(pref)) {
+			if (FLAT_POPUP_FACTORY_CLASS.equals(PopupFactory.getSharedInstance().getClass().getName())) {
+				PopupFactory.setSharedInstance(basicPopupFactory);
+			}
+		}
+		else if (POPUP_FACTORY_FLATLAF.equals(pref)) {
+			if (isFlatLaf) {
+				ensureFlatPopupFactoryInstalled();
+			}
+			else {
+				if (FLAT_POPUP_FACTORY_CLASS.equals(PopupFactory.getSharedInstance().getClass().getName())) {
+					PopupFactory.setSharedInstance(basicPopupFactory);
+				}
+			}
+		}
+		else {
+			// "auto" (default)
+			if (isFlatLaf) {
+				if (Compat.isJetBrainsRuntime()) {
+					UIManager.put("Popup.dropShadowPainted", Boolean.FALSE);
+				}
+				ensureFlatPopupFactoryInstalled();
+			}
+			else {
+				if (FLAT_POPUP_FACTORY_CLASS.equals(PopupFactory.getSharedInstance().getClass().getName())) {
+					PopupFactory.setSharedInstance(basicPopupFactory);
+				}
+			}
+		}
+	}
+
+	private static void ensureFlatPopupFactoryInstalled() {
+		if (!FLAT_POPUP_FACTORY_CLASS.equals(PopupFactory.getSharedInstance().getClass().getName())) {
+			try {
+				Class<?> factoryClass = FrameController.class.getClassLoader().loadClass(FLAT_POPUP_FACTORY_CLASS);
+				PopupFactory flatFactory = (PopupFactory) factoryClass.getDeclaredConstructor().newInstance();
+				PopupFactory.setSharedInstance(flatFactory);
+			}
+			catch (Throwable t) {
+				LogUtils.warn("Could not instantiate FlatPopupFactory, falling back to basicPopupFactory: " + t.getMessage());
+				PopupFactory.setSharedInstance(basicPopupFactory);
+			}
+		}
 	}
 
 	private static int obtainLookAndFeelDefaultMenuItemFontSize() {

--- a/freeplane/src/test/java/org/freeplane/core/util/CompatTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/util/CompatTest.java
@@ -1,0 +1,80 @@
+package org.freeplane.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CompatTest {
+    private String originalVendor;
+    private String originalVmVendor;
+    private String originalVendorVersion;
+
+    @Before
+    public void setUp() {
+        originalVendor = System.getProperty("java.vendor");
+        originalVmVendor = System.getProperty("java.vm.vendor");
+        originalVendorVersion = System.getProperty("java.vendor.version");
+    }
+
+    @After
+    public void tearDown() {
+        restoreProperty("java.vendor", originalVendor);
+        restoreProperty("java.vm.vendor", originalVmVendor);
+        restoreProperty("java.vendor.version", originalVendorVersion);
+    }
+
+    private void restoreProperty(String key, String value) {
+        if (value != null) {
+            System.setProperty(key, value);
+        } else {
+            System.clearProperty(key);
+        }
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withStandardJdk_returnsFalse() {
+        System.setProperty("java.vendor", "Azul Systems, Inc.");
+        System.setProperty("java.vm.vendor", "Azul Systems, Inc.");
+        System.setProperty("java.vendor.version", "Zulu21.38+21-CA");
+
+        assertThat(Compat.isJetBrainsRuntime()).isFalse();
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withJetBrainsVendor_returnsTrue() {
+        System.setProperty("java.vendor", "JetBrains s.r.o.");
+        System.setProperty("java.vm.vendor", "OpenJDK 64-Bit Server VM");
+        System.clearProperty("java.vendor.version");
+
+        assertThat(Compat.isJetBrainsRuntime()).isTrue();
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withJetBrainsVmVendor_returnsTrue() {
+        System.setProperty("java.vendor", "Oracle Corporation");
+        System.setProperty("java.vm.vendor", "JetBrains s.r.o.");
+        System.clearProperty("java.vendor.version");
+
+        assertThat(Compat.isJetBrainsRuntime()).isTrue();
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withJbrVendorVersion_returnsTrue() {
+        System.setProperty("java.vendor", "Custom");
+        System.setProperty("java.vm.vendor", "Custom VM");
+        System.setProperty("java.vendor.version", "JBR-21.0.8+9-1004.2-nomod");
+
+        assertThat(Compat.isJetBrainsRuntime()).isTrue();
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withNullOrEmptyProperties_returnsFalseWithoutException() {
+        System.clearProperty("java.vendor");
+        System.clearProperty("java.vm.vendor");
+        System.clearProperty("java.vendor.version");
+
+        assertThat(Compat.isJetBrainsRuntime()).isFalse();
+    }
+}

--- a/freeplane/src/test/java/org/freeplane/features/ui/PopupFactoryConfigurationTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/ui/PopupFactoryConfigurationTest.java
@@ -1,0 +1,152 @@
+package org.freeplane.features.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.swing.PopupFactory;
+import javax.swing.UIManager;
+import javax.swing.plaf.metal.MetalLookAndFeel;
+
+import org.freeplane.core.resources.ResourceController;
+import org.freeplane.core.util.Compat;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.formdev.flatlaf.FlatLightLaf;
+
+public class PopupFactoryConfigurationTest {
+    private static PopupFactory initialPopupFactory;
+    private MockedStatic<ResourceController> mockedResourceControllerStatic;
+    private ResourceController resourceControllerMock;
+    private String originalVendor;
+    private String originalVmVendor;
+    private String originalVendorVersion;
+
+    @BeforeClass
+    public static void saveInitialState() {
+        try {
+            Compat.setIsApplet(false);
+        } catch (IllegalStateException ignored) {
+        }
+        initialPopupFactory = PopupFactory.getSharedInstance();
+    }
+
+    @AfterClass
+    public static void restoreInitialState() {
+        PopupFactory.setSharedInstance(initialPopupFactory);
+    }
+
+    @Before
+    public void setUp() {
+        originalVendor = System.getProperty("java.vendor");
+        originalVmVendor = System.getProperty("java.vm.vendor");
+        originalVendorVersion = System.getProperty("java.vendor.version");
+
+        mockedResourceControllerStatic = Mockito.mockStatic(ResourceController.class);
+        resourceControllerMock = mock(ResourceController.class);
+        when(resourceControllerMock.getProperties()).thenReturn(new java.util.Properties());
+        mockedResourceControllerStatic.when(ResourceController::getResourceController).thenReturn(resourceControllerMock);
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn(FrameController.POPUP_FACTORY_AUTO);
+    }
+
+    @After
+    public void tearDown() {
+        mockedResourceControllerStatic.close();
+        restoreProperty("java.vendor", originalVendor);
+        restoreProperty("java.vm.vendor", originalVmVendor);
+        restoreProperty("java.vendor.version", originalVendorVersion);
+        UIManager.put("Popup.dropShadowPainted", null);
+        PopupFactory.setSharedInstance(new PopupFactory());
+    }
+
+    private void restoreProperty(String key, String value) {
+        if (value != null) {
+            System.setProperty(key, value);
+        } else {
+            System.clearProperty(key);
+        }
+    }
+
+    @Test
+    public void configurePopupFactory_withFlatLafAndAuto_installsFlatPopupFactory() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("auto");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_withFlatLafAndBasicPref_installsBasicPopupFactory() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("basic");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .doesNotContain("FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_withNonFlatLaf_revertsToBasicPopupFactory() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("auto");
+        UIManager.setLookAndFeel(new MetalLookAndFeel());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .doesNotContain("FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_onJbrRuntime_disablesDropShadowOnAuto() throws Exception {
+        System.setProperty("java.vendor", "JetBrains s.r.o.");
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("auto");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+        assertThat(UIManager.get("Popup.dropShadowPainted")).isEqualTo(Boolean.FALSE);
+    }
+
+    @Test
+    public void configurePopupFactory_dynamicLafSwitching() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("auto");
+
+        // Step A: Set FlatLaf -> verify FlatPopupFactory installed
+        UIManager.setLookAndFeel(new FlatLightLaf());
+        FrameController.configurePopupFactory();
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+
+        // Step B: Switch to Metal -> verify basic PopupFactory restored
+        UIManager.setLookAndFeel(new MetalLookAndFeel());
+        FrameController.configurePopupFactory();
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .doesNotContain("FlatPopupFactory");
+
+        // Step C: Switch back to FlatLaf -> verify FlatPopupFactory restored
+        UIManager.setLookAndFeel(new FlatLightLaf());
+        FrameController.configurePopupFactory();
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+    }
+}

--- a/freeplane/src/test/java/org/freeplane/features/ui/PopupFactoryConfigurationTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/ui/PopupFactoryConfigurationTest.java
@@ -149,4 +149,39 @@ public class PopupFactoryConfigurationTest {
         assertThat(PopupFactory.getSharedInstance().getClass().getName())
             .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
     }
+
+    @Test
+    public void configurePopupFactory_withInvalidPreference_fallsBackToAuto() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("invalid_value");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_withCaseInsensitiveAndWhitespacePreference_handlesCorrectly() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("  BASIC  ");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .doesNotContain("FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_withNullResourceController_defaultsToAuto() throws Exception {
+        UIManager.setLookAndFeel(new FlatLightLaf());
+        mockedResourceControllerStatic.when(ResourceController::getResourceController).thenReturn(null);
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+    }
 }

--- a/freeplane/src/viewer/resources/freeplane.properties
+++ b/freeplane/src/viewer/resources/freeplane.properties
@@ -848,4 +848,3 @@ showStatusBarOnError=true
 # 'flatlaf': Forces FlatPopupFactory when FlatLaf is active.
 # 'basic': Forces standard Swing PopupFactory (fallback if custom window managers encounter issues).
 freeplane.popup_factory=auto
-

--- a/freeplane/src/viewer/resources/freeplane.properties
+++ b/freeplane/src/viewer/resources/freeplane.properties
@@ -842,3 +842,10 @@ outputs_status_message_after_automatic_save=true
 outlineFilterHistorySize=10
 outlineTextWritingDirection=LEFT_TO_RIGHT
 showStatusBarOnError=true
+
+# Popup factory strategy: 'auto' (recommended), 'flatlaf', or 'basic'
+# 'auto': Uses multi-monitor-aware FlatPopupFactory for FlatLaf themes with JBR compatibility adjustments.
+# 'flatlaf': Forces FlatPopupFactory when FlatLaf is active.
+# 'basic': Forces standard Swing PopupFactory (fallback if custom window managers encounter issues).
+freeplane.popup_factory=auto
+


### PR DESCRIPTION
## Summary
- Retain FlatLaf's multi-monitor-aware `FlatPopupFactory` instead of unconditionally replacing it with Swing's basic factory.
- Add the `freeplane.popup_factory` `auto`, `flatlaf`, and `basic` strategies, including the JBR drop-shadow compatibility adjustment.
- Cover JVM detection, factory selection, fallback behavior, invalid preferences, and runtime LAF switching.

## Verification
- `gradle :freeplane:test --no-daemon --console=plain` under Java 21.0.8.
- `git diff --check upstream/1.13.x...HEAD`.
- Isolated current-build Java 21 UI probe from revision `aba242ab6816e0954da80d8ea1c87e5d9acd7b18`, with a disposable profile explicitly setting `freeplane.popup_factory=auto` and FlatLaf.
  File-menu mouse press and release left the PID-scoped popup visible directly beneath the focused frame on HDMI-1 (`5224,114` -> `5224,138`) and DP-3 (`2244,114` -> `2244,138`).