### PR TITLE
Fix multi-monitor popup placement after X11 maximization

### DIFF
--- a/freeplane/src/main/java/org/freeplane/core/util/Compat.java
+++ b/freeplane/src/main/java/org/freeplane/core/util/Compat.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import javax.swing.JFrame;
@@ -283,5 +284,22 @@ public class Compat {
 		}
 		else
 			Compat.isApplet = isApplet;
+	}
+
+	/**
+	 * Detects whether the current Java Virtual Machine is JetBrains Runtime (JBR).
+	 *
+	 * Checks java.vendor, java.vm.vendor, and java.vendor.version for presence of
+	 * "jetbrains" or "jbr" (case-insensitive).
+	 *
+	 * @return true if running under JetBrains Runtime, false otherwise
+	 */
+	public static boolean isJetBrainsRuntime() {
+		String vendor = System.getProperty("java.vendor", "");
+		String vmVendor = System.getProperty("java.vm.vendor", "");
+		String vendorVersion = System.getProperty("java.vendor.version", "");
+		return vendor.toLowerCase(Locale.ROOT).contains("jetbrains")
+			|| vmVendor.toLowerCase(Locale.ROOT).contains("jetbrains")
+			|| vendorVersion.toLowerCase(Locale.ROOT).contains("jbr");
 	}
 }

--- a/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
+++ b/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
@@ -702,7 +702,7 @@ abstract public class FrameController implements ViewController {
     private static void fixLookAndFeelUI(){
     	OSKeyBindingManager.applyToCurrentLookAndFeel();
     	configureFlatLookAndFeel();
-    	configurePopupFactory();
+		configurePopupFactory();
 		UIManager.put("Button.defaultButtonFollowsFocus", Boolean.TRUE);
 		UIManager.put("ComboBox.squareButton", Boolean.FALSE);
 		final ResourceController resourceController = ResourceController.getResourceController();

--- a/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
+++ b/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
@@ -102,6 +102,12 @@ import com.formdev.flatlaf.FlatLaf;
  * @author Dimitry Polivaev
  */
 abstract public class FrameController implements ViewController {
+	public static final String POPUP_FACTORY_PROPERTY = "freeplane.popup_factory";
+	public static final String POPUP_FACTORY_AUTO = "auto";
+	public static final String POPUP_FACTORY_FLATLAF = "flatlaf";
+	public static final String POPUP_FACTORY_BASIC = "basic";
+	public static final String FLAT_POPUP_FACTORY_CLASS = "com.formdev.flatlaf.ui.FlatPopupFactory";
+
 	public static final String VAQUA_LAF_NAME = "VAqua";
 	public static final String VAQUA_LAF_CLASS_NAME = "org.violetlib.aqua.AquaLookAndFeel";
     private static final String DARCULA_LAF_CLASS_NAME = "com.bulenkov.darcula.DarculaLaf";
@@ -665,8 +671,6 @@ abstract public class FrameController implements ViewController {
 						UIManager.setLookAndFeel((LookAndFeel) lookAndFeelClass.newInstance());
 						if (userLibClassLoader != uiClassLoader)
 							userLibClassLoader.close();
-						if(PopupFactory.getSharedInstance().getClass().getName().equals("com.formdev.flatlaf.ui.FlatPopupFactory"))
-							PopupFactory.setSharedInstance(basicPopupFactory);
 					}
 					catch (ClassNotFoundException | ClassCastException | InstantiationException e) {
 						LogUtils.warn("Error while setting Look&Feel " + lookAndFeel + ", reverted to default");
@@ -698,6 +702,7 @@ abstract public class FrameController implements ViewController {
     private static void fixLookAndFeelUI(){
     	OSKeyBindingManager.applyToCurrentLookAndFeel();
     	configureFlatLookAndFeel();
+    	configurePopupFactory();
 		UIManager.put("Button.defaultButtonFollowsFocus", Boolean.TRUE);
 		UIManager.put("ComboBox.squareButton", Boolean.FALSE);
 		final ResourceController resourceController = ResourceController.getResourceController();
@@ -732,6 +737,68 @@ abstract public class FrameController implements ViewController {
 		final Color color = UIManager.getColor("control");
 		if (color != null && color.getAlpha() < 255)
 			UIManager.getDefaults().put("control", Color.LIGHT_GRAY);
+	}
+
+	public static void configurePopupFactory() {
+		try {
+			if (Compat.isApplet()) {
+				return;
+			}
+		}
+		catch (IllegalStateException ex) {
+			// Compat.isApplet() throws IllegalStateException if not set (e.g. in standalone unit tests)
+		}
+
+		final ResourceController resourceController = ResourceController.getResourceController();
+		final String pref = (resourceController != null)
+			? resourceController.getProperty(POPUP_FACTORY_PROPERTY, POPUP_FACTORY_AUTO).trim().toLowerCase(java.util.Locale.ROOT)
+			: POPUP_FACTORY_AUTO;
+
+		final boolean isFlatLaf = UIManager.getLookAndFeel() instanceof FlatLaf;
+
+		if (POPUP_FACTORY_BASIC.equals(pref)) {
+			if (FLAT_POPUP_FACTORY_CLASS.equals(PopupFactory.getSharedInstance().getClass().getName())) {
+				PopupFactory.setSharedInstance(basicPopupFactory);
+			}
+		}
+		else if (POPUP_FACTORY_FLATLAF.equals(pref)) {
+			if (isFlatLaf) {
+				ensureFlatPopupFactoryInstalled();
+			}
+			else {
+				if (FLAT_POPUP_FACTORY_CLASS.equals(PopupFactory.getSharedInstance().getClass().getName())) {
+					PopupFactory.setSharedInstance(basicPopupFactory);
+				}
+			}
+		}
+		else {
+			// "auto" (default)
+			if (isFlatLaf) {
+				if (Compat.isJetBrainsRuntime()) {
+					UIManager.put("Popup.dropShadowPainted", Boolean.FALSE);
+				}
+				ensureFlatPopupFactoryInstalled();
+			}
+			else {
+				if (FLAT_POPUP_FACTORY_CLASS.equals(PopupFactory.getSharedInstance().getClass().getName())) {
+					PopupFactory.setSharedInstance(basicPopupFactory);
+				}
+			}
+		}
+	}
+
+	private static void ensureFlatPopupFactoryInstalled() {
+		if (!FLAT_POPUP_FACTORY_CLASS.equals(PopupFactory.getSharedInstance().getClass().getName())) {
+			try {
+				Class<?> factoryClass = FrameController.class.getClassLoader().loadClass(FLAT_POPUP_FACTORY_CLASS);
+				PopupFactory flatFactory = (PopupFactory) factoryClass.getDeclaredConstructor().newInstance();
+				PopupFactory.setSharedInstance(flatFactory);
+			}
+			catch (Throwable t) {
+				LogUtils.warn("Could not instantiate FlatPopupFactory, falling back to basicPopupFactory: " + t.getMessage());
+				PopupFactory.setSharedInstance(basicPopupFactory);
+			}
+		}
 	}
 
 	private static int obtainLookAndFeelDefaultMenuItemFontSize() {

--- a/freeplane/src/main/java/org/freeplane/main/application/ApplicationViewController.java
+++ b/freeplane/src/main/java/org/freeplane/main/application/ApplicationViewController.java
@@ -30,6 +30,7 @@ import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Image;
 import java.awt.Rectangle;
+import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -65,6 +66,31 @@ class ApplicationViewController extends FrameController {
 	private static final String APPWINDOW_X = "appwindow_x";
 	private static final String APPWINDOW_Y = "appwindow_y";
 	private static final String APPWINDOW_STATE = "appwindow_state";
+	private static final String X11_TOOLKIT_CLASS_NAME = "sun.awt.X11.XToolkit";
+
+	static boolean needsMaximizedFrameResynchronization(final boolean isX11Toolkit, final int windowState,
+			final Rectangle frameBounds, final Rectangle screenBounds) {
+		return isX11Toolkit && (windowState & Frame.ICONIFIED) == 0
+				&& (windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH
+				&& frameBounds != null && screenBounds != null
+				&& (frameBounds.x != screenBounds.x || frameBounds.y != screenBounds.y);
+	}
+
+	private static boolean isX11Toolkit() {
+		return X11_TOOLKIT_CLASS_NAME.equals(Toolkit.getDefaultToolkit().getClass().getName());
+	}
+
+	private static void resynchronizeMaximizedFrame(final JFrame frame, final int windowState) {
+		final GraphicsConfiguration graphicsConfiguration = frame.getGraphicsConfiguration();
+		if (graphicsConfiguration == null) {
+			return;
+		}
+		final Rectangle screenBounds = graphicsConfiguration.getBounds();
+		if (needsMaximizedFrameResynchronization(isX11Toolkit(), windowState, frame.getBounds(), screenBounds)) {
+			frame.setBounds(screenBounds);
+			frame.validate();
+		}
+	}
 
 	private static Image frameIcon(String size) {
         return new ImageIcon(ResourceController.getResourceController().getResource(
@@ -349,6 +375,7 @@ class ApplicationViewController extends FrameController {
 			 */
 		});
 		frame.setFocusTraversalKeysEnabled(false);
+		installMaximizedFrameResynchronization(frame);
         frame.setBounds(getStoredFrameBounds(frame));
 		frame.applyComponentOrientation(ComponentOrientation.getOrientation(Locale.getDefault()));
 
@@ -362,6 +389,25 @@ class ApplicationViewController extends FrameController {
 
 		// Register full screen listener for macOS
 		Compat.registerFullScreenListener(frame);
+	}
+
+	private void installMaximizedFrameResynchronization(final JFrame frame) {
+		final WindowAdapter frameResynchronizer = new WindowAdapter() {
+			@Override
+			public void windowOpened(final WindowEvent event) {
+				resynchronizeMaximizedFrame(frame, frame.getExtendedState());
+			}
+
+			@Override
+			public void windowStateChanged(final WindowEvent event) {
+				if ((event.getOldState() & Frame.MAXIMIZED_BOTH) != Frame.MAXIMIZED_BOTH
+						&& (event.getNewState() & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
+					resynchronizeMaximizedFrame(frame, event.getNewState());
+				}
+			}
+		};
+		frame.addWindowListener(frameResynchronizer);
+		frame.addWindowStateListener(frameResynchronizer);
 	}
 
 

--- a/freeplane/src/main/java/org/freeplane/main/application/ApplicationViewController.java
+++ b/freeplane/src/main/java/org/freeplane/main/application/ApplicationViewController.java
@@ -32,6 +32,8 @@ import java.awt.Image;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.Window;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.IOException;
@@ -68,12 +70,24 @@ class ApplicationViewController extends FrameController {
 	private static final String APPWINDOW_STATE = "appwindow_state";
 	private static final String X11_TOOLKIT_CLASS_NAME = "sun.awt.X11.XToolkit";
 
+	static boolean needsFrameResynchronization(final boolean isX11Toolkit, final int windowState,
+			final Rectangle frameBounds, final Rectangle targetBounds) {
+		return isX11Toolkit && (windowState & Frame.ICONIFIED) == 0
+				&& frameBounds != null && targetBounds != null
+				&& (frameBounds.x != targetBounds.x || frameBounds.y != targetBounds.y);
+	}
+
 	static boolean needsMaximizedFrameResynchronization(final boolean isX11Toolkit, final int windowState,
 			final Rectangle frameBounds, final Rectangle screenBounds) {
-		return isX11Toolkit && (windowState & Frame.ICONIFIED) == 0
-				&& (windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH
-				&& frameBounds != null && screenBounds != null
-				&& (frameBounds.x != screenBounds.x || frameBounds.y != screenBounds.y);
+		return (windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH
+				&& needsFrameResynchronization(isX11Toolkit, windowState, frameBounds, screenBounds);
+	}
+
+	static boolean needsNormalFrameResynchronization(final boolean isX11Toolkit, final int oldState,
+			final int newState, final Rectangle frameBounds, final Rectangle normalBounds) {
+		return (oldState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH
+				&& (newState & Frame.MAXIMIZED_BOTH) != Frame.MAXIMIZED_BOTH
+				&& needsFrameResynchronization(isX11Toolkit, newState, frameBounds, normalBounds);
 	}
 
 	private static boolean isX11Toolkit() {
@@ -85,9 +99,13 @@ class ApplicationViewController extends FrameController {
 		if (graphicsConfiguration == null) {
 			return;
 		}
-		final Rectangle screenBounds = graphicsConfiguration.getBounds();
-		if (needsMaximizedFrameResynchronization(isX11Toolkit(), windowState, frame.getBounds(), screenBounds)) {
-			frame.setBounds(screenBounds);
+		resynchronizeFrame(frame, windowState, graphicsConfiguration.getBounds());
+	}
+
+	private static void resynchronizeFrame(final JFrame frame, final int windowState,
+			final Rectangle targetBounds) {
+		if (needsFrameResynchronization(isX11Toolkit(), windowState, frame.getBounds(), targetBounds)) {
+			frame.setBounds(targetBounds);
 			frame.validate();
 		}
 	}
@@ -375,8 +393,8 @@ class ApplicationViewController extends FrameController {
 			 */
 		});
 		frame.setFocusTraversalKeysEnabled(false);
-		installMaximizedFrameResynchronization(frame);
         frame.setBounds(getStoredFrameBounds(frame));
+		installMaximizedFrameResynchronization(frame);
 		frame.applyComponentOrientation(ComponentOrientation.getOrientation(Locale.getDefault()));
 
 
@@ -391,23 +409,78 @@ class ApplicationViewController extends FrameController {
 		Compat.registerFullScreenListener(frame);
 	}
 
-	private void installMaximizedFrameResynchronization(final JFrame frame) {
-		final WindowAdapter frameResynchronizer = new WindowAdapter() {
-			@Override
-			public void windowOpened(final WindowEvent event) {
-				resynchronizeMaximizedFrame(frame, frame.getExtendedState());
-			}
-
-			@Override
-			public void windowStateChanged(final WindowEvent event) {
-				if ((event.getOldState() & Frame.MAXIMIZED_BOTH) != Frame.MAXIMIZED_BOTH
-						&& (event.getNewState() & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
-					resynchronizeMaximizedFrame(frame, event.getNewState());
-				}
-			}
-		};
+	private static void installMaximizedFrameResynchronization(final JFrame frame) {
+		final FrameResynchronizer frameResynchronizer = new FrameResynchronizer(frame);
 		frame.addWindowListener(frameResynchronizer);
 		frame.addWindowStateListener(frameResynchronizer);
+		frame.addComponentListener(frameResynchronizer);
+	}
+
+	private static final class FrameResynchronizer extends WindowAdapter implements ComponentListener {
+		private final JFrame frame;
+		private Rectangle normalBounds;
+		private int lastKnownWindowState;
+
+		private FrameResynchronizer(final JFrame frame) {
+			this.frame = frame;
+			normalBounds = new Rectangle(frame.getBounds());
+			lastKnownWindowState = frame.getExtendedState();
+		}
+
+		@Override
+		public void windowOpened(final WindowEvent event) {
+			final int windowState = frame.getExtendedState();
+			lastKnownWindowState = windowState;
+			if ((windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
+				resynchronizeMaximizedFrame(frame, windowState);
+			}
+			else {
+				rememberNormalBounds();
+			}
+		}
+
+		@Override
+		public void windowStateChanged(final WindowEvent event) {
+			final int oldState = event.getOldState();
+			final int newState = event.getNewState();
+			lastKnownWindowState = newState;
+			if ((oldState & Frame.MAXIMIZED_BOTH) != Frame.MAXIMIZED_BOTH
+					&& (newState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
+				resynchronizeMaximizedFrame(frame, newState);
+			}
+			else if (needsNormalFrameResynchronization(isX11Toolkit(), oldState, newState,
+					frame.getBounds(), normalBounds)) {
+				resynchronizeFrame(frame, newState, normalBounds);
+			}
+		}
+
+		@Override
+		public void componentMoved(final ComponentEvent event) {
+			rememberNormalBounds();
+		}
+
+		@Override
+		public void componentResized(final ComponentEvent event) {
+			rememberNormalBounds();
+		}
+
+		@Override
+		public void componentShown(final ComponentEvent event) {
+		}
+
+		@Override
+		public void componentHidden(final ComponentEvent event) {
+		}
+
+		private void rememberNormalBounds() {
+			if (isNormalWindowState(lastKnownWindowState) && isNormalWindowState(frame.getExtendedState())) {
+				normalBounds = new Rectangle(frame.getBounds());
+			}
+		}
+	}
+
+	private static boolean isNormalWindowState(final int windowState) {
+		return (windowState & (Frame.MAXIMIZED_BOTH | Frame.ICONIFIED)) == 0;
 	}
 
 

--- a/freeplane/src/test/java/org/freeplane/core/util/CompatTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/util/CompatTest.java
@@ -1,0 +1,80 @@
+package org.freeplane.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CompatTest {
+    private String originalVendor;
+    private String originalVmVendor;
+    private String originalVendorVersion;
+
+    @Before
+    public void setUp() {
+        originalVendor = System.getProperty("java.vendor");
+        originalVmVendor = System.getProperty("java.vm.vendor");
+        originalVendorVersion = System.getProperty("java.vendor.version");
+    }
+
+    @After
+    public void tearDown() {
+        restoreProperty("java.vendor", originalVendor);
+        restoreProperty("java.vm.vendor", originalVmVendor);
+        restoreProperty("java.vendor.version", originalVendorVersion);
+    }
+
+    private void restoreProperty(String key, String value) {
+        if (value != null) {
+            System.setProperty(key, value);
+        } else {
+            System.clearProperty(key);
+        }
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withStandardJdk_returnsFalse() {
+        System.setProperty("java.vendor", "Azul Systems, Inc.");
+        System.setProperty("java.vm.vendor", "Azul Systems, Inc.");
+        System.setProperty("java.vendor.version", "Zulu21.38+21-CA");
+
+        assertThat(Compat.isJetBrainsRuntime()).isFalse();
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withJetBrainsVendor_returnsTrue() {
+        System.setProperty("java.vendor", "JetBrains s.r.o.");
+        System.setProperty("java.vm.vendor", "OpenJDK 64-Bit Server VM");
+        System.clearProperty("java.vendor.version");
+
+        assertThat(Compat.isJetBrainsRuntime()).isTrue();
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withJetBrainsVmVendor_returnsTrue() {
+        System.setProperty("java.vendor", "Oracle Corporation");
+        System.setProperty("java.vm.vendor", "JetBrains s.r.o.");
+        System.clearProperty("java.vendor.version");
+
+        assertThat(Compat.isJetBrainsRuntime()).isTrue();
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withJbrVendorVersion_returnsTrue() {
+        System.setProperty("java.vendor", "Custom");
+        System.setProperty("java.vm.vendor", "Custom VM");
+        System.setProperty("java.vendor.version", "JBR-21.0.8+9-1004.2-nomod");
+
+        assertThat(Compat.isJetBrainsRuntime()).isTrue();
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withNullOrEmptyProperties_returnsFalseWithoutException() {
+        System.clearProperty("java.vendor");
+        System.clearProperty("java.vm.vendor");
+        System.clearProperty("java.vendor.version");
+
+        assertThat(Compat.isJetBrainsRuntime()).isFalse();
+    }
+}

--- a/freeplane/src/test/java/org/freeplane/features/ui/PopupFactoryConfigurationTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/ui/PopupFactoryConfigurationTest.java
@@ -1,0 +1,152 @@
+package org.freeplane.features.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.swing.PopupFactory;
+import javax.swing.UIManager;
+import javax.swing.plaf.metal.MetalLookAndFeel;
+
+import org.freeplane.core.resources.ResourceController;
+import org.freeplane.core.util.Compat;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.formdev.flatlaf.FlatLightLaf;
+
+public class PopupFactoryConfigurationTest {
+    private static PopupFactory initialPopupFactory;
+    private MockedStatic<ResourceController> mockedResourceControllerStatic;
+    private ResourceController resourceControllerMock;
+    private String originalVendor;
+    private String originalVmVendor;
+    private String originalVendorVersion;
+
+    @BeforeClass
+    public static void saveInitialState() {
+        try {
+            Compat.setIsApplet(false);
+        } catch (IllegalStateException ignored) {
+        }
+        initialPopupFactory = PopupFactory.getSharedInstance();
+    }
+
+    @AfterClass
+    public static void restoreInitialState() {
+        PopupFactory.setSharedInstance(initialPopupFactory);
+    }
+
+    @Before
+    public void setUp() {
+        originalVendor = System.getProperty("java.vendor");
+        originalVmVendor = System.getProperty("java.vm.vendor");
+        originalVendorVersion = System.getProperty("java.vendor.version");
+
+        mockedResourceControllerStatic = Mockito.mockStatic(ResourceController.class);
+        resourceControllerMock = mock(ResourceController.class);
+        when(resourceControllerMock.getProperties()).thenReturn(new java.util.Properties());
+        mockedResourceControllerStatic.when(ResourceController::getResourceController).thenReturn(resourceControllerMock);
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn(FrameController.POPUP_FACTORY_AUTO);
+    }
+
+    @After
+    public void tearDown() {
+        mockedResourceControllerStatic.close();
+        restoreProperty("java.vendor", originalVendor);
+        restoreProperty("java.vm.vendor", originalVmVendor);
+        restoreProperty("java.vendor.version", originalVendorVersion);
+        UIManager.put("Popup.dropShadowPainted", null);
+        PopupFactory.setSharedInstance(new PopupFactory());
+    }
+
+    private void restoreProperty(String key, String value) {
+        if (value != null) {
+            System.setProperty(key, value);
+        } else {
+            System.clearProperty(key);
+        }
+    }
+
+    @Test
+    public void configurePopupFactory_withFlatLafAndAuto_installsFlatPopupFactory() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("auto");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_withFlatLafAndBasicPref_installsBasicPopupFactory() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("basic");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .doesNotContain("FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_withNonFlatLaf_revertsToBasicPopupFactory() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("auto");
+        UIManager.setLookAndFeel(new MetalLookAndFeel());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .doesNotContain("FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_onJbrRuntime_disablesDropShadowOnAuto() throws Exception {
+        System.setProperty("java.vendor", "JetBrains s.r.o.");
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("auto");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+        assertThat(UIManager.get("Popup.dropShadowPainted")).isEqualTo(Boolean.FALSE);
+    }
+
+    @Test
+    public void configurePopupFactory_dynamicLafSwitching() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("auto");
+
+        // Step A: Set FlatLaf -> verify FlatPopupFactory installed
+        UIManager.setLookAndFeel(new FlatLightLaf());
+        FrameController.configurePopupFactory();
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+
+        // Step B: Switch to Metal -> verify basic PopupFactory restored
+        UIManager.setLookAndFeel(new MetalLookAndFeel());
+        FrameController.configurePopupFactory();
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .doesNotContain("FlatPopupFactory");
+
+        // Step C: Switch back to FlatLaf -> verify FlatPopupFactory restored
+        UIManager.setLookAndFeel(new FlatLightLaf());
+        FrameController.configurePopupFactory();
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+    }
+}

--- a/freeplane/src/test/java/org/freeplane/features/ui/PopupFactoryConfigurationTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/ui/PopupFactoryConfigurationTest.java
@@ -149,4 +149,39 @@ public class PopupFactoryConfigurationTest {
         assertThat(PopupFactory.getSharedInstance().getClass().getName())
             .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
     }
+
+    @Test
+    public void configurePopupFactory_withInvalidPreference_fallsBackToAuto() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("invalid_value");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_withCaseInsensitiveAndWhitespacePreference_handlesCorrectly() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("  BASIC  ");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .doesNotContain("FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_withNullResourceController_defaultsToAuto() throws Exception {
+        UIManager.setLookAndFeel(new FlatLightLaf());
+        mockedResourceControllerStatic.when(ResourceController::getResourceController).thenReturn(null);
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+    }
 }

--- a/freeplane/src/test/java/org/freeplane/main/application/ApplicationViewControllerTest.java
+++ b/freeplane/src/test/java/org/freeplane/main/application/ApplicationViewControllerTest.java
@@ -1,0 +1,66 @@
+package org.freeplane.main.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.awt.Frame;
+import java.awt.Rectangle;
+
+import org.junit.Test;
+
+public class ApplicationViewControllerTest {
+    private static final Rectangle PRIMARY_SCREEN = new Rectangle(0, 0, 2560, 1440);
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withStaleX11FrameLocation_returnsTrue() {
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isTrue();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withNonX11Toolkit_returnsFalse() {
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            false, Frame.MAXIMIZED_BOTH, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withoutBothMaximizeStateBits_returnsFalse() {
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_HORIZ, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_whenIconified_returnsFalse() {
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH | Frame.ICONIFIED, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withCurrentSecondaryScreenOrigin_returnsFalse() {
+        final Rectangle secondaryScreen = new Rectangle(2560, 0, 1920, 1080);
+
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, new Rectangle(2560, 0, 1920, 1080), secondaryScreen)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withStaleSecondaryScreenLocation_returnsTrue() {
+        final Rectangle secondaryScreen = new Rectangle(2560, 0, 1920, 1080);
+
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, new Rectangle(150, 100, 1920, 1080), secondaryScreen)).isTrue();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withMissingBounds_returnsFalse() {
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, null, PRIMARY_SCREEN)).isFalse();
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, PRIMARY_SCREEN, null)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withCurrentScreenOrigin_returnsFalse() {
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, new Rectangle(0, 0, 2560, 1440), PRIMARY_SCREEN)).isFalse();
+    }
+}

--- a/freeplane/src/test/java/org/freeplane/main/application/ApplicationViewControllerTest.java
+++ b/freeplane/src/test/java/org/freeplane/main/application/ApplicationViewControllerTest.java
@@ -11,6 +11,91 @@ public class ApplicationViewControllerTest {
     private static final Rectangle PRIMARY_SCREEN = new Rectangle(0, 0, 2560, 1440);
 
     @Test
+    public void needsFrameResynchronization_withStaleNormalX11FrameLocation_returnsTrue() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsFrameResynchronization(
+            true, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), restoredBounds)).isTrue();
+    }
+
+    @Test
+    public void needsFrameResynchronization_withCurrentNormalFrameLocation_returnsFalse() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsFrameResynchronization(
+            true, Frame.NORMAL, restoredBounds, restoredBounds)).isFalse();
+    }
+
+    @Test
+    public void needsFrameResynchronization_withNonX11Toolkit_returnsFalse() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsFrameResynchronization(
+            false, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), restoredBounds)).isFalse();
+    }
+
+    @Test
+    public void needsFrameResynchronization_whenIconified_returnsFalse() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsFrameResynchronization(
+            true, Frame.NORMAL | Frame.ICONIFIED, new Rectangle(1920, 0, 1912, 1008), restoredBounds)).isFalse();
+    }
+
+    @Test
+    public void needsFrameResynchronization_withMissingBounds_returnsFalse() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsFrameResynchronization(
+            true, Frame.NORMAL, null, restoredBounds)).isFalse();
+        assertThat(ApplicationViewController.needsFrameResynchronization(
+            true, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), null)).isFalse();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_whenLeavingMaximizedWithStaleLocation_returnsTrue() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsNormalFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), normalBounds)).isTrue();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_whenStillMaximized_returnsFalse() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsNormalFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, Frame.MAXIMIZED_BOTH,
+            new Rectangle(1920, 0, 1912, 1008), normalBounds)).isFalse();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_whenNotLeavingMaximized_returnsFalse() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsNormalFrameResynchronization(
+            true, Frame.NORMAL, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), normalBounds)).isFalse();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_whenIconified_returnsFalse() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsNormalFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, Frame.ICONIFIED,
+            new Rectangle(1920, 0, 1912, 1008), normalBounds)).isFalse();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_withNonX11Toolkit_returnsFalse() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsNormalFrameResynchronization(
+            false, Frame.MAXIMIZED_BOTH, Frame.NORMAL,
+            new Rectangle(1920, 0, 1912, 1008), normalBounds)).isFalse();
+    }
+
+    @Test
     public void needsMaximizedFrameResynchronization_withStaleX11FrameLocation_returnsTrue() {
         assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
             true, Frame.MAXIMIZED_BOTH, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isTrue();

--- a/freeplane/src/viewer/resources/freeplane.properties
+++ b/freeplane/src/viewer/resources/freeplane.properties
@@ -848,4 +848,3 @@ showStatusBarOnError=true
 # 'flatlaf': Forces FlatPopupFactory when FlatLaf is active.
 # 'basic': Forces standard Swing PopupFactory (fallback if custom window managers encounter issues).
 freeplane.popup_factory=auto
-

--- a/freeplane/src/viewer/resources/freeplane.properties
+++ b/freeplane/src/viewer/resources/freeplane.properties
@@ -842,3 +842,10 @@ outputs_status_message_after_automatic_save=true
 outlineFilterHistorySize=10
 outlineTextWritingDirection=LEFT_TO_RIGHT
 showStatusBarOnError=true
+
+# Popup factory strategy: 'auto' (recommended), 'flatlaf', or 'basic'
+# 'auto': Uses multi-monitor-aware FlatPopupFactory for FlatLaf themes with JBR compatibility adjustments.
+# 'flatlaf': Forces FlatPopupFactory when FlatLaf is active.
+# 'basic': Forces standard Swing PopupFactory (fallback if custom window managers encounter issues).
+freeplane.popup_factory=auto
+


### PR DESCRIPTION
## Summary

- Retain FlatLaf's multi-monitor-aware `FlatPopupFactory` instead of replacing it with Swing's basic factory, with an explicit `freeplane.popup_factory=auto|flatlaf|basic` fallback.
- Resynchronize stale Java 11/X11 frame coordinates under KWin when a Freeplane window opens maximized, enters `MAXIMIZED_BOTH`, or exits it, preserving the tracked normal geometry across the transitions.
- Add focused regression coverage for X11, full/partial maximize state, iconification, null bounds, normal geometry tracking, and secondary-monitor origins.

Supersedes closed #2978, which covered only the PopupFactory portion before the Java 11/KWin maximization failure was reproduced.

## Verification

- `gradle --project-dir=/data/home/guest/Development/freeplane/.worktrees/popup-factory-multimonitor :freeplane:test --rerun-tasks --no-daemon --console=plain` under Java 21.0.8-zulu: `BUILD SUCCESSFUL`.
- `gradle --project-dir=/data/home/guest/Development/freeplane/.worktrees/popup-factory-multimonitor build -x check_translation -x :freeplane:check_translation -x :JOrtho_0.4_freeplane:check_translation --no-daemon --console=plain` under Java 21.0.8-zulu: `BUILD SUCCESSFUL`. The three translation checks remain excluded because of pre-existing `Resources_es.properties` and `Resources_uk_UA.properties` failures; the build also reports pre-existing Javadoc diagnostics.
- The focused runtime distribution is stamped with revision `497fc94b06675104e00fe8d3b83952f049d4447b` in `BIN/resources/gitinfo.properties`.
- Isolated X11/KWin 6.7.4 runs with OpenJDK 11.0.32.1 and FlatLaf verified the actual pointer press/release path. Startup-maximized opened the File popup at `(0,24)` and retained `selectedCount=3` after release. A maximize, restore, remaximize cycle reported native client geometry `(0,0,2560x1440)`, `(154,134,1592x860)`, and `(0,0,2560x1440)`; File popup release retained `selectedCount=3` at `(0,24)`, `(154,158)`, and `(0,24)` respectively.

The runtime evidence was collected from the focused worktree distribution, with disposable probe processes isolated from the active Freeplane instance.
