### PR TITLE
Fix popup placement on multi-monitor setups (FlatPopupFactory retention and X11 coordinate resynchronization)

### DIFF
--- a/freeplane/src/main/java/org/freeplane/core/util/Compat.java
+++ b/freeplane/src/main/java/org/freeplane/core/util/Compat.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import javax.swing.JFrame;
@@ -283,5 +284,22 @@ public class Compat {
 		}
 		else
 			Compat.isApplet = isApplet;
+	}
+
+	/**
+	 * Detects whether the current Java Virtual Machine is JetBrains Runtime (JBR).
+	 *
+	 * Checks java.vendor, java.vm.vendor, and java.vendor.version for presence of
+	 * "jetbrains" or "jbr" (case-insensitive).
+	 *
+	 * @return true if running under JetBrains Runtime, false otherwise
+	 */
+	public static boolean isJetBrainsRuntime() {
+		String vendor = System.getProperty("java.vendor", "");
+		String vmVendor = System.getProperty("java.vm.vendor", "");
+		String vendorVersion = System.getProperty("java.vendor.version", "");
+		return vendor.toLowerCase(Locale.ROOT).contains("jetbrains")
+			|| vmVendor.toLowerCase(Locale.ROOT).contains("jetbrains")
+			|| vendorVersion.toLowerCase(Locale.ROOT).contains("jbr");
 	}
 }

--- a/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
+++ b/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
@@ -702,7 +702,7 @@ abstract public class FrameController implements ViewController {
     private static void fixLookAndFeelUI(){
     	OSKeyBindingManager.applyToCurrentLookAndFeel();
     	configureFlatLookAndFeel();
-    	configurePopupFactory();
+		configurePopupFactory();
 		UIManager.put("Button.defaultButtonFollowsFocus", Boolean.TRUE);
 		UIManager.put("ComboBox.squareButton", Boolean.FALSE);
 		final ResourceController resourceController = ResourceController.getResourceController();

--- a/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
+++ b/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
@@ -102,6 +102,12 @@ import com.formdev.flatlaf.FlatLaf;
  * @author Dimitry Polivaev
  */
 abstract public class FrameController implements ViewController {
+	public static final String POPUP_FACTORY_PROPERTY = "freeplane.popup_factory";
+	public static final String POPUP_FACTORY_AUTO = "auto";
+	public static final String POPUP_FACTORY_FLATLAF = "flatlaf";
+	public static final String POPUP_FACTORY_BASIC = "basic";
+	public static final String FLAT_POPUP_FACTORY_CLASS = "com.formdev.flatlaf.ui.FlatPopupFactory";
+
 	public static final String VAQUA_LAF_NAME = "VAqua";
 	public static final String VAQUA_LAF_CLASS_NAME = "org.violetlib.aqua.AquaLookAndFeel";
     private static final String DARCULA_LAF_CLASS_NAME = "com.bulenkov.darcula.DarculaLaf";
@@ -665,8 +671,6 @@ abstract public class FrameController implements ViewController {
 						UIManager.setLookAndFeel((LookAndFeel) lookAndFeelClass.newInstance());
 						if (userLibClassLoader != uiClassLoader)
 							userLibClassLoader.close();
-						if(PopupFactory.getSharedInstance().getClass().getName().equals("com.formdev.flatlaf.ui.FlatPopupFactory"))
-							PopupFactory.setSharedInstance(basicPopupFactory);
 					}
 					catch (ClassNotFoundException | ClassCastException | InstantiationException e) {
 						LogUtils.warn("Error while setting Look&Feel " + lookAndFeel + ", reverted to default");
@@ -698,6 +702,7 @@ abstract public class FrameController implements ViewController {
     private static void fixLookAndFeelUI(){
     	OSKeyBindingManager.applyToCurrentLookAndFeel();
     	configureFlatLookAndFeel();
+    	configurePopupFactory();
 		UIManager.put("Button.defaultButtonFollowsFocus", Boolean.TRUE);
 		UIManager.put("ComboBox.squareButton", Boolean.FALSE);
 		final ResourceController resourceController = ResourceController.getResourceController();
@@ -732,6 +737,68 @@ abstract public class FrameController implements ViewController {
 		final Color color = UIManager.getColor("control");
 		if (color != null && color.getAlpha() < 255)
 			UIManager.getDefaults().put("control", Color.LIGHT_GRAY);
+	}
+
+	public static void configurePopupFactory() {
+		try {
+			if (Compat.isApplet()) {
+				return;
+			}
+		}
+		catch (IllegalStateException ex) {
+			// Compat.isApplet() throws IllegalStateException if not set (e.g. in standalone unit tests)
+		}
+
+		final ResourceController resourceController = ResourceController.getResourceController();
+		final String pref = (resourceController != null)
+			? resourceController.getProperty(POPUP_FACTORY_PROPERTY, POPUP_FACTORY_AUTO).trim().toLowerCase(java.util.Locale.ROOT)
+			: POPUP_FACTORY_AUTO;
+
+		final boolean isFlatLaf = UIManager.getLookAndFeel() instanceof FlatLaf;
+
+		if (POPUP_FACTORY_BASIC.equals(pref)) {
+			if (FLAT_POPUP_FACTORY_CLASS.equals(PopupFactory.getSharedInstance().getClass().getName())) {
+				PopupFactory.setSharedInstance(basicPopupFactory);
+			}
+		}
+		else if (POPUP_FACTORY_FLATLAF.equals(pref)) {
+			if (isFlatLaf) {
+				ensureFlatPopupFactoryInstalled();
+			}
+			else {
+				if (FLAT_POPUP_FACTORY_CLASS.equals(PopupFactory.getSharedInstance().getClass().getName())) {
+					PopupFactory.setSharedInstance(basicPopupFactory);
+				}
+			}
+		}
+		else {
+			// "auto" (default)
+			if (isFlatLaf) {
+				if (Compat.isJetBrainsRuntime()) {
+					UIManager.put("Popup.dropShadowPainted", Boolean.FALSE);
+				}
+				ensureFlatPopupFactoryInstalled();
+			}
+			else {
+				if (FLAT_POPUP_FACTORY_CLASS.equals(PopupFactory.getSharedInstance().getClass().getName())) {
+					PopupFactory.setSharedInstance(basicPopupFactory);
+				}
+			}
+		}
+	}
+
+	private static void ensureFlatPopupFactoryInstalled() {
+		if (!FLAT_POPUP_FACTORY_CLASS.equals(PopupFactory.getSharedInstance().getClass().getName())) {
+			try {
+				Class<?> factoryClass = FrameController.class.getClassLoader().loadClass(FLAT_POPUP_FACTORY_CLASS);
+				PopupFactory flatFactory = (PopupFactory) factoryClass.getDeclaredConstructor().newInstance();
+				PopupFactory.setSharedInstance(flatFactory);
+			}
+			catch (Throwable t) {
+				LogUtils.warn("Could not instantiate FlatPopupFactory, falling back to basicPopupFactory: " + t.getMessage());
+				PopupFactory.setSharedInstance(basicPopupFactory);
+			}
+		}
 	}
 
 	private static int obtainLookAndFeelDefaultMenuItemFontSize() {

--- a/freeplane/src/main/java/org/freeplane/main/application/ApplicationViewController.java
+++ b/freeplane/src/main/java/org/freeplane/main/application/ApplicationViewController.java
@@ -30,6 +30,7 @@ import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Image;
 import java.awt.Rectangle;
+import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -65,6 +66,31 @@ class ApplicationViewController extends FrameController {
 	private static final String APPWINDOW_X = "appwindow_x";
 	private static final String APPWINDOW_Y = "appwindow_y";
 	private static final String APPWINDOW_STATE = "appwindow_state";
+	private static final String X11_TOOLKIT_CLASS_NAME = "sun.awt.X11.XToolkit";
+
+	static boolean needsMaximizedFrameResynchronization(final boolean isX11Toolkit, final int windowState,
+			final Rectangle frameBounds, final Rectangle screenBounds) {
+		return isX11Toolkit && (windowState & Frame.ICONIFIED) == 0
+				&& (windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH
+				&& frameBounds != null && screenBounds != null
+				&& (frameBounds.x != screenBounds.x || frameBounds.y != screenBounds.y);
+	}
+
+	private static boolean isX11Toolkit() {
+		return X11_TOOLKIT_CLASS_NAME.equals(Toolkit.getDefaultToolkit().getClass().getName());
+	}
+
+	private static void resynchronizeMaximizedFrame(final JFrame frame, final int windowState) {
+		final GraphicsConfiguration graphicsConfiguration = frame.getGraphicsConfiguration();
+		if (graphicsConfiguration == null) {
+			return;
+		}
+		final Rectangle screenBounds = graphicsConfiguration.getBounds();
+		if (needsMaximizedFrameResynchronization(isX11Toolkit(), windowState, frame.getBounds(), screenBounds)) {
+			frame.setBounds(screenBounds);
+			frame.validate();
+		}
+	}
 
 	private static Image frameIcon(String size) {
         return new ImageIcon(ResourceController.getResourceController().getResource(
@@ -349,6 +375,7 @@ class ApplicationViewController extends FrameController {
 			 */
 		});
 		frame.setFocusTraversalKeysEnabled(false);
+		installMaximizedFrameResynchronization(frame);
         frame.setBounds(getStoredFrameBounds(frame));
 		frame.applyComponentOrientation(ComponentOrientation.getOrientation(Locale.getDefault()));
 
@@ -362,6 +389,25 @@ class ApplicationViewController extends FrameController {
 
 		// Register full screen listener for macOS
 		Compat.registerFullScreenListener(frame);
+	}
+
+	private void installMaximizedFrameResynchronization(final JFrame frame) {
+		final WindowAdapter frameResynchronizer = new WindowAdapter() {
+			@Override
+			public void windowOpened(final WindowEvent event) {
+				resynchronizeMaximizedFrame(frame, frame.getExtendedState());
+			}
+
+			@Override
+			public void windowStateChanged(final WindowEvent event) {
+				if ((event.getOldState() & Frame.MAXIMIZED_BOTH) != Frame.MAXIMIZED_BOTH
+						&& (event.getNewState() & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
+					resynchronizeMaximizedFrame(frame, event.getNewState());
+				}
+			}
+		};
+		frame.addWindowListener(frameResynchronizer);
+		frame.addWindowStateListener(frameResynchronizer);
 	}
 
 

--- a/freeplane/src/main/java/org/freeplane/main/application/ApplicationViewController.java
+++ b/freeplane/src/main/java/org/freeplane/main/application/ApplicationViewController.java
@@ -32,6 +32,8 @@ import java.awt.Image;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.Window;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.IOException;
@@ -68,12 +70,24 @@ class ApplicationViewController extends FrameController {
 	private static final String APPWINDOW_STATE = "appwindow_state";
 	private static final String X11_TOOLKIT_CLASS_NAME = "sun.awt.X11.XToolkit";
 
+	static boolean needsFrameResynchronization(final boolean isX11Toolkit, final int windowState,
+			final Rectangle frameBounds, final Rectangle targetBounds) {
+		return isX11Toolkit && (windowState & Frame.ICONIFIED) == 0
+				&& frameBounds != null && targetBounds != null
+				&& (frameBounds.x != targetBounds.x || frameBounds.y != targetBounds.y);
+	}
+
 	static boolean needsMaximizedFrameResynchronization(final boolean isX11Toolkit, final int windowState,
 			final Rectangle frameBounds, final Rectangle screenBounds) {
-		return isX11Toolkit && (windowState & Frame.ICONIFIED) == 0
-				&& (windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH
-				&& frameBounds != null && screenBounds != null
-				&& (frameBounds.x != screenBounds.x || frameBounds.y != screenBounds.y);
+		return (windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH
+				&& needsFrameResynchronization(isX11Toolkit, windowState, frameBounds, screenBounds);
+	}
+
+	static boolean needsNormalFrameResynchronization(final boolean isX11Toolkit, final int oldState,
+			final int newState, final Rectangle frameBounds, final Rectangle normalBounds) {
+		return (oldState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH
+				&& (newState & Frame.MAXIMIZED_BOTH) != Frame.MAXIMIZED_BOTH
+				&& needsFrameResynchronization(isX11Toolkit, newState, frameBounds, normalBounds);
 	}
 
 	private static boolean isX11Toolkit() {
@@ -85,9 +99,13 @@ class ApplicationViewController extends FrameController {
 		if (graphicsConfiguration == null) {
 			return;
 		}
-		final Rectangle screenBounds = graphicsConfiguration.getBounds();
-		if (needsMaximizedFrameResynchronization(isX11Toolkit(), windowState, frame.getBounds(), screenBounds)) {
-			frame.setBounds(screenBounds);
+		resynchronizeFrame(frame, windowState, graphicsConfiguration.getBounds());
+	}
+
+	private static void resynchronizeFrame(final JFrame frame, final int windowState,
+			final Rectangle targetBounds) {
+		if (needsFrameResynchronization(isX11Toolkit(), windowState, frame.getBounds(), targetBounds)) {
+			frame.setBounds(targetBounds);
 			frame.validate();
 		}
 	}
@@ -375,8 +393,8 @@ class ApplicationViewController extends FrameController {
 			 */
 		});
 		frame.setFocusTraversalKeysEnabled(false);
-		installMaximizedFrameResynchronization(frame);
         frame.setBounds(getStoredFrameBounds(frame));
+		installMaximizedFrameResynchronization(frame);
 		frame.applyComponentOrientation(ComponentOrientation.getOrientation(Locale.getDefault()));
 
 
@@ -391,23 +409,78 @@ class ApplicationViewController extends FrameController {
 		Compat.registerFullScreenListener(frame);
 	}
 
-	private void installMaximizedFrameResynchronization(final JFrame frame) {
-		final WindowAdapter frameResynchronizer = new WindowAdapter() {
-			@Override
-			public void windowOpened(final WindowEvent event) {
-				resynchronizeMaximizedFrame(frame, frame.getExtendedState());
-			}
-
-			@Override
-			public void windowStateChanged(final WindowEvent event) {
-				if ((event.getOldState() & Frame.MAXIMIZED_BOTH) != Frame.MAXIMIZED_BOTH
-						&& (event.getNewState() & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
-					resynchronizeMaximizedFrame(frame, event.getNewState());
-				}
-			}
-		};
+	private static void installMaximizedFrameResynchronization(final JFrame frame) {
+		final FrameResynchronizer frameResynchronizer = new FrameResynchronizer(frame);
 		frame.addWindowListener(frameResynchronizer);
 		frame.addWindowStateListener(frameResynchronizer);
+		frame.addComponentListener(frameResynchronizer);
+	}
+
+	private static final class FrameResynchronizer extends WindowAdapter implements ComponentListener {
+		private final JFrame frame;
+		private Rectangle normalBounds;
+		private int lastKnownWindowState;
+
+		private FrameResynchronizer(final JFrame frame) {
+			this.frame = frame;
+			normalBounds = new Rectangle(frame.getBounds());
+			lastKnownWindowState = frame.getExtendedState();
+		}
+
+		@Override
+		public void windowOpened(final WindowEvent event) {
+			final int windowState = frame.getExtendedState();
+			lastKnownWindowState = windowState;
+			if ((windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
+				resynchronizeMaximizedFrame(frame, windowState);
+			}
+			else {
+				rememberNormalBounds();
+			}
+		}
+
+		@Override
+		public void windowStateChanged(final WindowEvent event) {
+			final int oldState = event.getOldState();
+			final int newState = event.getNewState();
+			lastKnownWindowState = newState;
+			if ((oldState & Frame.MAXIMIZED_BOTH) != Frame.MAXIMIZED_BOTH
+					&& (newState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
+				resynchronizeMaximizedFrame(frame, newState);
+			}
+			else if (needsNormalFrameResynchronization(isX11Toolkit(), oldState, newState,
+					frame.getBounds(), normalBounds)) {
+				resynchronizeFrame(frame, newState, normalBounds);
+			}
+		}
+
+		@Override
+		public void componentMoved(final ComponentEvent event) {
+			rememberNormalBounds();
+		}
+
+		@Override
+		public void componentResized(final ComponentEvent event) {
+			rememberNormalBounds();
+		}
+
+		@Override
+		public void componentShown(final ComponentEvent event) {
+		}
+
+		@Override
+		public void componentHidden(final ComponentEvent event) {
+		}
+
+		private void rememberNormalBounds() {
+			if (isNormalWindowState(lastKnownWindowState) && isNormalWindowState(frame.getExtendedState())) {
+				normalBounds = new Rectangle(frame.getBounds());
+			}
+		}
+	}
+
+	private static boolean isNormalWindowState(final int windowState) {
+		return (windowState & (Frame.MAXIMIZED_BOTH | Frame.ICONIFIED)) == 0;
 	}
 
 

--- a/freeplane/src/main/java/org/freeplane/main/application/ApplicationViewController.java
+++ b/freeplane/src/main/java/org/freeplane/main/application/ApplicationViewController.java
@@ -69,12 +69,31 @@ class ApplicationViewController extends FrameController {
 	private static final String APPWINDOW_Y = "appwindow_y";
 	private static final String APPWINDOW_STATE = "appwindow_state";
 	private static final String X11_TOOLKIT_CLASS_NAME = "sun.awt.X11.XToolkit";
+	private static final int RESYNCHRONIZATION_TOLERANCE = 4;
 
 	static boolean needsFrameResynchronization(final boolean isX11Toolkit, final int windowState,
 			final Rectangle frameBounds, final Rectangle targetBounds) {
 		return isX11Toolkit && (windowState & Frame.ICONIFIED) == 0
 				&& frameBounds != null && targetBounds != null
 				&& (frameBounds.x != targetBounds.x || frameBounds.y != targetBounds.y);
+	}
+
+	static boolean needsNormalWindowResynchronization(final boolean isX11Toolkit, final int windowState,
+			final Rectangle frameBounds, final Rectangle nativeBounds) {
+		if (!isX11Toolkit
+				|| (windowState & (Frame.MAXIMIZED_BOTH | Frame.ICONIFIED)) != 0
+				|| frameBounds == null || nativeBounds == null) {
+			return false;
+		}
+		// Only trust the native geometry while the window sizes agree. A size
+		// difference indicates the window manager is still placing or resizing the
+		// window, and acting on such transient geometry makes the window shrink.
+		if (Math.abs(frameBounds.width - nativeBounds.width) > RESYNCHRONIZATION_TOLERANCE
+				|| Math.abs(frameBounds.height - nativeBounds.height) > RESYNCHRONIZATION_TOLERANCE) {
+			return false;
+		}
+		return Math.abs(frameBounds.x - nativeBounds.x) > RESYNCHRONIZATION_TOLERANCE
+				|| Math.abs(frameBounds.y - nativeBounds.y) > RESYNCHRONIZATION_TOLERANCE;
 	}
 
 	static boolean needsMaximizedFrameResynchronization(final boolean isX11Toolkit, final int windowState,
@@ -90,16 +109,213 @@ class ApplicationViewController extends FrameController {
 				&& needsFrameResynchronization(isX11Toolkit, newState, frameBounds, normalBounds);
 	}
 
+	static Rectangle findTargetScreenBounds(final Rectangle frameBounds, final Rectangle[] screenBounds) {
+		if (frameBounds == null || screenBounds == null) {
+			return null;
+		}
+		Rectangle targetBounds = null;
+		long largestIntersectionArea = 0;
+		for (final Rectangle screenBound : screenBounds) {
+			if (screenBound == null) {
+				continue;
+			}
+			final Rectangle intersection = frameBounds.intersection(screenBound);
+			final long intersectionArea = (long) Math.max(0, intersection.width)
+					* Math.max(0, intersection.height);
+			if (intersectionArea > largestIntersectionArea) {
+				largestIntersectionArea = intersectionArea;
+				targetBounds = screenBound;
+			}
+		}
+		return targetBounds == null ? null : new Rectangle(targetBounds);
+	}
+
 	private static boolean isX11Toolkit() {
 		return X11_TOOLKIT_CLASS_NAME.equals(Toolkit.getDefaultToolkit().getClass().getName());
 	}
 
-	private static void resynchronizeMaximizedFrame(final JFrame frame, final int windowState) {
+	private static boolean resynchronizeMaximizedFrame(final JFrame frame, final int windowState,
+			final Rectangle nativeBounds, final Rectangle normalBounds) {
+		Rectangle targetBounds = null;
+		if (nativeBounds != null) {
+			targetBounds = findTargetScreenBounds(nativeBounds, getScreenBounds());
+		}
+		if (targetBounds == null) {
+			targetBounds = findTargetScreenBounds(normalBounds, getScreenBounds());
+		}
+		if (targetBounds != null) {
+			if (needsMaximizedFrameResynchronization(isX11Toolkit(), windowState, frame.getBounds(), targetBounds)) {
+				resynchronizeFrame(frame, windowState, targetBounds);
+				return false;
+			}
+			return true;
+		}
 		final GraphicsConfiguration graphicsConfiguration = frame.getGraphicsConfiguration();
 		if (graphicsConfiguration == null) {
-			return;
+			return true;
 		}
-		resynchronizeFrame(frame, windowState, graphicsConfiguration.getBounds());
+		if (needsMaximizedFrameResynchronization(isX11Toolkit(), windowState, frame.getBounds(), graphicsConfiguration.getBounds())) {
+			resynchronizeFrame(frame, windowState, graphicsConfiguration.getBounds());
+			return false;
+		}
+		return true;
+	}
+
+	private static void resynchronizeNormalFrame(final JFrame frame, final int windowState,
+			final Rectangle nativeBounds) {
+		if (needsNormalWindowResynchronization(isX11Toolkit(), windowState, frame.getBounds(), nativeBounds)) {
+			frame.setBounds(nativeBounds);
+			frame.validate();
+		}
+	}
+
+	/**
+	 * Returns the current window manager frame bounds (including decorations) of the
+	 * given component as a screen rectangle in logical pixels, or {@code null} if the
+	 * bounds cannot be queried or are implausible (e.g. while the window is still
+	 * being placed). Only available on the X11 toolkit and only when the component
+	 * has a native shell window.
+	 */
+	static Rectangle getNativeWindowBounds(final Component component) {
+		if (!isX11Toolkit() || component == null) {
+			return null;
+		}
+		com.sun.jna.platform.unix.X11.Display display = null;
+		try {
+			final long shell = java.security.AccessController.doPrivileged(
+					new java.security.PrivilegedExceptionAction<Long>() {
+						@Override
+						public Long run() throws Exception {
+							final Class<?> awtAccessor = Class.forName("sun.awt.AWTAccessor");
+							final Object componentAccessor = awtAccessor.getMethod("getComponentAccessor").invoke(null);
+							final java.lang.reflect.Method getPeer = Class.forName("sun.awt.AWTAccessor$ComponentAccessor")
+									.getMethod("getPeer", Component.class);
+							getPeer.setAccessible(true);
+							final Object peer = getPeer.invoke(componentAccessor, component);
+							if (peer == null) {
+								return 0L;
+							}
+							final java.lang.reflect.Method getShell = peer.getClass().getMethod("getShell");
+							getShell.setAccessible(true);
+							return ((Number) getShell.invoke(peer)).longValue();
+						}
+					});
+			if (shell == 0) {
+				return null;
+			}
+			display = com.sun.jna.platform.unix.X11.INSTANCE.XOpenDisplay(null);
+			if (display == null) {
+				return null;
+			}
+			final com.sun.jna.platform.unix.X11.Window root = com.sun.jna.platform.unix.X11.INSTANCE.XDefaultRootWindow(display);
+			final com.sun.jna.platform.unix.X11.Window shellWindow = new com.sun.jna.platform.unix.X11.Window(shell);
+			// Query the client window's root position and size.
+			final com.sun.jna.ptr.IntByReference x = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.IntByReference y = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.platform.unix.X11.WindowByReference child = new com.sun.jna.platform.unix.X11.WindowByReference();
+			final boolean translated = com.sun.jna.platform.unix.X11.INSTANCE.XTranslateCoordinates(
+					display, shellWindow, root, 0, 0, x, y, child);
+			if (!translated) {
+				return null;
+			}
+			final com.sun.jna.ptr.IntByReference rootX = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.IntByReference rootY = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.IntByReference width = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.IntByReference height = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.IntByReference border = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.IntByReference depth = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.platform.unix.X11.WindowByReference geometryRoot = new com.sun.jna.platform.unix.X11.WindowByReference();
+			final int status = com.sun.jna.platform.unix.X11.INSTANCE.XGetGeometry(
+					display, new com.sun.jna.platform.unix.X11.Drawable(shell), geometryRoot,
+					rootX, rootY, width, height, border, depth);
+			if (status == 0) {
+				return null;
+			}
+			// Add the window manager decoration extents to obtain the outer frame
+			// bounds as java.awt.Component bounds are reported. EWMH order is
+			// left, right, top, bottom.
+			final int[] frameExtents = readFrameExtents(display, shellWindow);
+			final int left = frameExtents[0];
+			final int right = frameExtents[1];
+			final int top = frameExtents[2];
+			final int bottom = frameExtents[3];
+			final int outerWidth = width.getValue() + left + right;
+			final int outerHeight = height.getValue() + top + bottom;
+			if (outerWidth < 100 || outerHeight < 100) {
+				// Implausible geometry; the window is probably not placed yet.
+				return null;
+			}
+			final GraphicsConfiguration gc = component.getGraphicsConfiguration();
+			final java.awt.geom.AffineTransform transform = gc == null ? null : gc.getDefaultTransform();
+			final double scaleX = transform == null ? 1.0 : transform.getScaleX();
+			final double scaleY = transform == null ? 1.0 : transform.getScaleY();
+			final int logicalX = (int) Math.round((x.getValue() - left) / (scaleX > 0 ? scaleX : 1.0));
+			final int logicalY = (int) Math.round((y.getValue() - top) / (scaleY > 0 ? scaleY : 1.0));
+			final int logicalW = (int) Math.round(outerWidth / (scaleX > 0 ? scaleX : 1.0));
+			final int logicalH = (int) Math.round(outerHeight / (scaleY > 0 ? scaleY : 1.0));
+			return new Rectangle(logicalX, logicalY, logicalW, logicalH);
+		}
+		catch (Throwable throwable) {
+			return null;
+		}
+		finally {
+			if (display != null) {
+				try {
+					com.sun.jna.platform.unix.X11.INSTANCE.XCloseDisplay(display);
+				}
+				catch (Throwable ignored) {
+				}
+			}
+		}
+	}
+
+	/**
+	 * Reads the {@code _NET_FRAME_EXTENTS} property of the given window as an array of
+	 * left, top, right, bottom decoration sizes. Returns an array of zeros when the
+	 * property is missing or unreadable.
+	 */
+	private static int[] readFrameExtents(final com.sun.jna.platform.unix.X11.Display display,
+			final com.sun.jna.platform.unix.X11.Window window) {
+		final int[] result = new int[4];
+		try {
+			final com.sun.jna.platform.unix.X11.Atom atom = com.sun.jna.platform.unix.X11.INSTANCE.XInternAtom(display,
+					"_NET_FRAME_EXTENTS", false);
+			final com.sun.jna.platform.unix.X11.AtomByReference actualType = new com.sun.jna.platform.unix.X11.AtomByReference();
+			final com.sun.jna.ptr.IntByReference actualFormat = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.NativeLongByReference nitems = new com.sun.jna.ptr.NativeLongByReference();
+			final com.sun.jna.ptr.NativeLongByReference bytesAfter = new com.sun.jna.ptr.NativeLongByReference();
+			final com.sun.jna.ptr.PointerByReference property = new com.sun.jna.ptr.PointerByReference();
+			final int status = com.sun.jna.platform.unix.X11.INSTANCE.XGetWindowProperty(display, window, atom,
+					new com.sun.jna.NativeLong(0), new com.sun.jna.NativeLong(4), false, new com.sun.jna.platform.unix.X11.Atom(0),
+					actualType, actualFormat, nitems, bytesAfter, property);
+			if (status == 0 && actualFormat.getValue() == 32 && property.getValue() != null) {
+				final int count = (int) Math.min(4, nitems.getValue().longValue());
+				if (count >= 4) {
+					// On LP64 systems Xlib returns 32-bit format properties as 64-bit
+					// longs; the EWMH order is left, right, top, bottom.
+					final long[] values = property.getValue().getLongArray(0, 4);
+					for (int i = 0; i < result.length; i++) {
+						result[i] = (int) values[i];
+					}
+				}
+			}
+			if (property.getValue() != null) {
+				com.sun.jna.platform.unix.X11.INSTANCE.XFree(property.getValue());
+			}
+		}
+		catch (Throwable ignored) {
+		}
+		return result;
+	}
+
+	private static Rectangle[] getScreenBounds() {
+		final GraphicsDevice[] screenDevices = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices();
+		final Rectangle[] screenBounds = new Rectangle[screenDevices.length];
+		for (int i = 0; i < screenDevices.length; i++) {
+			final GraphicsConfiguration graphicsConfiguration = screenDevices[i].getDefaultConfiguration();
+			screenBounds[i] = graphicsConfiguration == null ? null : graphicsConfiguration.getBounds();
+		}
+		return screenBounds;
 	}
 
 	private static void resynchronizeFrame(final JFrame frame, final int windowState,
@@ -420,6 +636,10 @@ class ApplicationViewController extends FrameController {
 		private final JFrame frame;
 		private Rectangle normalBounds;
 		private int lastKnownWindowState;
+		private boolean isResynchronizing;
+		private javax.swing.Timer deferredResynchronizationTimer;
+		private int deferredResynchronizationAttempts;
+		private static final int MAX_DEFERRED_RESYNCHRONIZATION_ATTEMPTS = 10;
 
 		private FrameResynchronizer(final JFrame frame) {
 			this.frame = frame;
@@ -429,14 +649,9 @@ class ApplicationViewController extends FrameController {
 
 		@Override
 		public void windowOpened(final WindowEvent event) {
-			final int windowState = frame.getExtendedState();
-			lastKnownWindowState = windowState;
-			if ((windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
-				resynchronizeMaximizedFrame(frame, windowState);
-			}
-			else {
-				rememberNormalBounds();
-			}
+			lastKnownWindowState = frame.getExtendedState();
+			resynchronizeOnStableState();
+			scheduleDeferredResynchronization();
 		}
 
 		@Override
@@ -446,22 +661,28 @@ class ApplicationViewController extends FrameController {
 			lastKnownWindowState = newState;
 			if ((oldState & Frame.MAXIMIZED_BOTH) != Frame.MAXIMIZED_BOTH
 					&& (newState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
-				resynchronizeMaximizedFrame(frame, newState);
+				resynchronizeOnStableState();
 			}
 			else if (needsNormalFrameResynchronization(isX11Toolkit(), oldState, newState,
 					frame.getBounds(), normalBounds)) {
-				resynchronizeFrame(frame, newState, normalBounds);
+				runGuardedResynchronization(new Runnable() {
+					@Override
+					public void run() {
+						resynchronizeFrame(frame, newState, normalBounds);
+						rememberNormalBounds();
+					}
+				});
 			}
 		}
 
 		@Override
 		public void componentMoved(final ComponentEvent event) {
-			rememberNormalBounds();
+			handleComponentGeometryChanged();
 		}
 
 		@Override
 		public void componentResized(final ComponentEvent event) {
-			rememberNormalBounds();
+			handleComponentGeometryChanged();
 		}
 
 		@Override
@@ -470,6 +691,102 @@ class ApplicationViewController extends FrameController {
 
 		@Override
 		public void componentHidden(final ComponentEvent event) {
+		}
+
+		private void handleComponentGeometryChanged() {
+			if (isResynchronizing) {
+				return;
+			}
+			final int windowState = frame.getExtendedState();
+			if ((windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
+				resynchronizeOnStableState();
+			}
+			else if (isNormalWindowState(windowState)) {
+				resynchronizeOnStableState();
+			}
+			else {
+				rememberNormalBounds();
+			}
+			scheduleDeferredResynchronization();
+		}
+
+		private void scheduleDeferredResynchronization() {
+			// The window manager may still be moving the window when the component
+			// event is delivered; the AWT position cache is not necessarily updated
+			// by the same event. Recheck shortly afterwards until the geometry is
+			// stable, but do not retry forever.
+			if (deferredResynchronizationTimer != null) {
+				deferredResynchronizationTimer.stop();
+			}
+			deferredResynchronizationAttempts = 0;
+			startDeferredResynchronization(200);
+		}
+
+		private void startDeferredResynchronization(final int delay) {
+			deferredResynchronizationTimer = new javax.swing.Timer(delay, new java.awt.event.ActionListener() {
+				@Override
+				public void actionPerformed(final java.awt.event.ActionEvent event) {
+					deferredResynchronizationTimer = null;
+					final boolean stable = resynchronizeOnStableState();
+					if (!stable && deferredResynchronizationAttempts < MAX_DEFERRED_RESYNCHRONIZATION_ATTEMPTS) {
+						deferredResynchronizationAttempts++;
+						startDeferredResynchronization(200);
+					}
+				}
+			});
+			deferredResynchronizationTimer.setRepeats(false);
+			deferredResynchronizationTimer.start();
+		}
+
+		private boolean resynchronizeOnStableState() {
+			final boolean[] stable = new boolean[1];
+			runGuardedResynchronization(new Runnable() {
+				@Override
+				public void run() {
+					final int windowState = frame.getExtendedState();
+					lastKnownWindowState = windowState;
+					final Rectangle nativeBounds = getNativeWindowBounds(frame);
+					if ((windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
+						stable[0] = resynchronizeMaximizedFrame(frame, windowState, nativeBounds, normalBounds);
+					}
+					else if (isNormalWindowState(windowState)) {
+						// Native geometry that differs in size is likely transient; keep
+						// retrying until the window manager has finished placing the window.
+						if (nativeBounds == null) {
+							stable[0] = true;
+						}
+						else {
+							final Rectangle frameBounds = frame.getBounds();
+							final boolean sizesMatch =
+									Math.abs(frameBounds.width - nativeBounds.width) <= RESYNCHRONIZATION_TOLERANCE
+											&& Math.abs(frameBounds.height - nativeBounds.height) <= RESYNCHRONIZATION_TOLERANCE;
+							stable[0] = sizesMatch && !needsNormalWindowResynchronization(isX11Toolkit(),
+									windowState, frameBounds, nativeBounds);
+						}
+						if (nativeBounds != null) {
+							resynchronizeNormalFrame(frame, windowState, nativeBounds);
+						}
+						rememberNormalBounds();
+					}
+					else {
+						stable[0] = true;
+					}
+				}
+			});
+			return stable[0];
+		}
+
+		private void runGuardedResynchronization(final Runnable resynchronization) {
+			if (isResynchronizing) {
+				return;
+			}
+			isResynchronizing = true;
+			try {
+				resynchronization.run();
+			}
+			finally {
+				isResynchronizing = false;
+			}
 		}
 
 		private void rememberNormalBounds() {

--- a/freeplane/src/test/java/org/freeplane/core/util/CompatTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/util/CompatTest.java
@@ -1,0 +1,80 @@
+package org.freeplane.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CompatTest {
+    private String originalVendor;
+    private String originalVmVendor;
+    private String originalVendorVersion;
+
+    @Before
+    public void setUp() {
+        originalVendor = System.getProperty("java.vendor");
+        originalVmVendor = System.getProperty("java.vm.vendor");
+        originalVendorVersion = System.getProperty("java.vendor.version");
+    }
+
+    @After
+    public void tearDown() {
+        restoreProperty("java.vendor", originalVendor);
+        restoreProperty("java.vm.vendor", originalVmVendor);
+        restoreProperty("java.vendor.version", originalVendorVersion);
+    }
+
+    private void restoreProperty(String key, String value) {
+        if (value != null) {
+            System.setProperty(key, value);
+        } else {
+            System.clearProperty(key);
+        }
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withStandardJdk_returnsFalse() {
+        System.setProperty("java.vendor", "Azul Systems, Inc.");
+        System.setProperty("java.vm.vendor", "Azul Systems, Inc.");
+        System.setProperty("java.vendor.version", "Zulu21.38+21-CA");
+
+        assertThat(Compat.isJetBrainsRuntime()).isFalse();
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withJetBrainsVendor_returnsTrue() {
+        System.setProperty("java.vendor", "JetBrains s.r.o.");
+        System.setProperty("java.vm.vendor", "OpenJDK 64-Bit Server VM");
+        System.clearProperty("java.vendor.version");
+
+        assertThat(Compat.isJetBrainsRuntime()).isTrue();
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withJetBrainsVmVendor_returnsTrue() {
+        System.setProperty("java.vendor", "Oracle Corporation");
+        System.setProperty("java.vm.vendor", "JetBrains s.r.o.");
+        System.clearProperty("java.vendor.version");
+
+        assertThat(Compat.isJetBrainsRuntime()).isTrue();
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withJbrVendorVersion_returnsTrue() {
+        System.setProperty("java.vendor", "Custom");
+        System.setProperty("java.vm.vendor", "Custom VM");
+        System.setProperty("java.vendor.version", "JBR-21.0.8+9-1004.2-nomod");
+
+        assertThat(Compat.isJetBrainsRuntime()).isTrue();
+    }
+
+    @Test
+    public void isJetBrainsRuntime_withNullOrEmptyProperties_returnsFalseWithoutException() {
+        System.clearProperty("java.vendor");
+        System.clearProperty("java.vm.vendor");
+        System.clearProperty("java.vendor.version");
+
+        assertThat(Compat.isJetBrainsRuntime()).isFalse();
+    }
+}

--- a/freeplane/src/test/java/org/freeplane/features/ui/PopupFactoryConfigurationTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/ui/PopupFactoryConfigurationTest.java
@@ -1,0 +1,152 @@
+package org.freeplane.features.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.swing.PopupFactory;
+import javax.swing.UIManager;
+import javax.swing.plaf.metal.MetalLookAndFeel;
+
+import org.freeplane.core.resources.ResourceController;
+import org.freeplane.core.util.Compat;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.formdev.flatlaf.FlatLightLaf;
+
+public class PopupFactoryConfigurationTest {
+    private static PopupFactory initialPopupFactory;
+    private MockedStatic<ResourceController> mockedResourceControllerStatic;
+    private ResourceController resourceControllerMock;
+    private String originalVendor;
+    private String originalVmVendor;
+    private String originalVendorVersion;
+
+    @BeforeClass
+    public static void saveInitialState() {
+        try {
+            Compat.setIsApplet(false);
+        } catch (IllegalStateException ignored) {
+        }
+        initialPopupFactory = PopupFactory.getSharedInstance();
+    }
+
+    @AfterClass
+    public static void restoreInitialState() {
+        PopupFactory.setSharedInstance(initialPopupFactory);
+    }
+
+    @Before
+    public void setUp() {
+        originalVendor = System.getProperty("java.vendor");
+        originalVmVendor = System.getProperty("java.vm.vendor");
+        originalVendorVersion = System.getProperty("java.vendor.version");
+
+        mockedResourceControllerStatic = Mockito.mockStatic(ResourceController.class);
+        resourceControllerMock = mock(ResourceController.class);
+        when(resourceControllerMock.getProperties()).thenReturn(new java.util.Properties());
+        mockedResourceControllerStatic.when(ResourceController::getResourceController).thenReturn(resourceControllerMock);
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn(FrameController.POPUP_FACTORY_AUTO);
+    }
+
+    @After
+    public void tearDown() {
+        mockedResourceControllerStatic.close();
+        restoreProperty("java.vendor", originalVendor);
+        restoreProperty("java.vm.vendor", originalVmVendor);
+        restoreProperty("java.vendor.version", originalVendorVersion);
+        UIManager.put("Popup.dropShadowPainted", null);
+        PopupFactory.setSharedInstance(new PopupFactory());
+    }
+
+    private void restoreProperty(String key, String value) {
+        if (value != null) {
+            System.setProperty(key, value);
+        } else {
+            System.clearProperty(key);
+        }
+    }
+
+    @Test
+    public void configurePopupFactory_withFlatLafAndAuto_installsFlatPopupFactory() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("auto");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_withFlatLafAndBasicPref_installsBasicPopupFactory() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("basic");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .doesNotContain("FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_withNonFlatLaf_revertsToBasicPopupFactory() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("auto");
+        UIManager.setLookAndFeel(new MetalLookAndFeel());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .doesNotContain("FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_onJbrRuntime_disablesDropShadowOnAuto() throws Exception {
+        System.setProperty("java.vendor", "JetBrains s.r.o.");
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("auto");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+        assertThat(UIManager.get("Popup.dropShadowPainted")).isEqualTo(Boolean.FALSE);
+    }
+
+    @Test
+    public void configurePopupFactory_dynamicLafSwitching() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("auto");
+
+        // Step A: Set FlatLaf -> verify FlatPopupFactory installed
+        UIManager.setLookAndFeel(new FlatLightLaf());
+        FrameController.configurePopupFactory();
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+
+        // Step B: Switch to Metal -> verify basic PopupFactory restored
+        UIManager.setLookAndFeel(new MetalLookAndFeel());
+        FrameController.configurePopupFactory();
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .doesNotContain("FlatPopupFactory");
+
+        // Step C: Switch back to FlatLaf -> verify FlatPopupFactory restored
+        UIManager.setLookAndFeel(new FlatLightLaf());
+        FrameController.configurePopupFactory();
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+    }
+}

--- a/freeplane/src/test/java/org/freeplane/features/ui/PopupFactoryConfigurationTest.java
+++ b/freeplane/src/test/java/org/freeplane/features/ui/PopupFactoryConfigurationTest.java
@@ -149,4 +149,39 @@ public class PopupFactoryConfigurationTest {
         assertThat(PopupFactory.getSharedInstance().getClass().getName())
             .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
     }
+
+    @Test
+    public void configurePopupFactory_withInvalidPreference_fallsBackToAuto() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("invalid_value");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_withCaseInsensitiveAndWhitespacePreference_handlesCorrectly() throws Exception {
+        when(resourceControllerMock.getProperty(eq(FrameController.POPUP_FACTORY_PROPERTY), anyString()))
+            .thenReturn("  BASIC  ");
+        UIManager.setLookAndFeel(new FlatLightLaf());
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .doesNotContain("FlatPopupFactory");
+    }
+
+    @Test
+    public void configurePopupFactory_withNullResourceController_defaultsToAuto() throws Exception {
+        UIManager.setLookAndFeel(new FlatLightLaf());
+        mockedResourceControllerStatic.when(ResourceController::getResourceController).thenReturn(null);
+
+        FrameController.configurePopupFactory();
+
+        assertThat(PopupFactory.getSharedInstance().getClass().getName())
+            .isEqualTo("com.formdev.flatlaf.ui.FlatPopupFactory");
+    }
 }

--- a/freeplane/src/test/java/org/freeplane/main/application/ApplicationViewControllerTest.java
+++ b/freeplane/src/test/java/org/freeplane/main/application/ApplicationViewControllerTest.java
@@ -1,0 +1,66 @@
+package org.freeplane.main.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.awt.Frame;
+import java.awt.Rectangle;
+
+import org.junit.Test;
+
+public class ApplicationViewControllerTest {
+    private static final Rectangle PRIMARY_SCREEN = new Rectangle(0, 0, 2560, 1440);
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withStaleX11FrameLocation_returnsTrue() {
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isTrue();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withNonX11Toolkit_returnsFalse() {
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            false, Frame.MAXIMIZED_BOTH, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withoutBothMaximizeStateBits_returnsFalse() {
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_HORIZ, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_whenIconified_returnsFalse() {
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH | Frame.ICONIFIED, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withCurrentSecondaryScreenOrigin_returnsFalse() {
+        final Rectangle secondaryScreen = new Rectangle(2560, 0, 1920, 1080);
+
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, new Rectangle(2560, 0, 1920, 1080), secondaryScreen)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withStaleSecondaryScreenLocation_returnsTrue() {
+        final Rectangle secondaryScreen = new Rectangle(2560, 0, 1920, 1080);
+
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, new Rectangle(150, 100, 1920, 1080), secondaryScreen)).isTrue();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withMissingBounds_returnsFalse() {
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, null, PRIMARY_SCREEN)).isFalse();
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, PRIMARY_SCREEN, null)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withCurrentScreenOrigin_returnsFalse() {
+        assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, new Rectangle(0, 0, 2560, 1440), PRIMARY_SCREEN)).isFalse();
+    }
+}

--- a/freeplane/src/test/java/org/freeplane/main/application/ApplicationViewControllerTest.java
+++ b/freeplane/src/test/java/org/freeplane/main/application/ApplicationViewControllerTest.java
@@ -11,6 +11,91 @@ public class ApplicationViewControllerTest {
     private static final Rectangle PRIMARY_SCREEN = new Rectangle(0, 0, 2560, 1440);
 
     @Test
+    public void needsFrameResynchronization_withStaleNormalX11FrameLocation_returnsTrue() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsFrameResynchronization(
+            true, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), restoredBounds)).isTrue();
+    }
+
+    @Test
+    public void needsFrameResynchronization_withCurrentNormalFrameLocation_returnsFalse() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsFrameResynchronization(
+            true, Frame.NORMAL, restoredBounds, restoredBounds)).isFalse();
+    }
+
+    @Test
+    public void needsFrameResynchronization_withNonX11Toolkit_returnsFalse() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsFrameResynchronization(
+            false, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), restoredBounds)).isFalse();
+    }
+
+    @Test
+    public void needsFrameResynchronization_whenIconified_returnsFalse() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsFrameResynchronization(
+            true, Frame.NORMAL | Frame.ICONIFIED, new Rectangle(1920, 0, 1912, 1008), restoredBounds)).isFalse();
+    }
+
+    @Test
+    public void needsFrameResynchronization_withMissingBounds_returnsFalse() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsFrameResynchronization(
+            true, Frame.NORMAL, null, restoredBounds)).isFalse();
+        assertThat(ApplicationViewController.needsFrameResynchronization(
+            true, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), null)).isFalse();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_whenLeavingMaximizedWithStaleLocation_returnsTrue() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsNormalFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), normalBounds)).isTrue();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_whenStillMaximized_returnsFalse() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsNormalFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, Frame.MAXIMIZED_BOTH,
+            new Rectangle(1920, 0, 1912, 1008), normalBounds)).isFalse();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_whenNotLeavingMaximized_returnsFalse() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsNormalFrameResynchronization(
+            true, Frame.NORMAL, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), normalBounds)).isFalse();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_whenIconified_returnsFalse() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsNormalFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, Frame.ICONIFIED,
+            new Rectangle(1920, 0, 1912, 1008), normalBounds)).isFalse();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_withNonX11Toolkit_returnsFalse() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(ApplicationViewController.needsNormalFrameResynchronization(
+            false, Frame.MAXIMIZED_BOTH, Frame.NORMAL,
+            new Rectangle(1920, 0, 1912, 1008), normalBounds)).isFalse();
+    }
+
+    @Test
     public void needsMaximizedFrameResynchronization_withStaleX11FrameLocation_returnsTrue() {
         assertThat(ApplicationViewController.needsMaximizedFrameResynchronization(
             true, Frame.MAXIMIZED_BOTH, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isTrue();

--- a/freeplane/src/test/java/org/freeplane/main/application/ApplicationViewControllerTest.java
+++ b/freeplane/src/test/java/org/freeplane/main/application/ApplicationViewControllerTest.java
@@ -9,6 +9,118 @@ import org.junit.Test;
 
 public class ApplicationViewControllerTest {
     private static final Rectangle PRIMARY_SCREEN = new Rectangle(0, 0, 2560, 1440);
+    private static final Rectangle LEFT_SCREEN = new Rectangle(0, 0, 1920, 1080);
+    private static final Rectangle RIGHT_SCREEN = new Rectangle(5120, 0, 1920, 1080);
+
+    @Test
+    public void findTargetScreenBounds_withNativeGeometry_matchesContainingScreen() {
+        // Native geometry reports window on LEFT_SCREEN (0, 0, 1920x1080)
+        // even if stale normalBounds was on RIGHT_SCREEN (5120, 0, 1920x1080)
+        final Rectangle nativeBounds = new Rectangle(0, 32, 1920, 1048);
+
+        assertThat(ApplicationViewController.findTargetScreenBounds(nativeBounds,
+            new Rectangle[] { LEFT_SCREEN, PRIMARY_SCREEN, RIGHT_SCREEN })).isEqualTo(LEFT_SCREEN);
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_withMismatchedPositions_returnsTrue() {
+        // KWin placed the normal window on LEFT_SCREEN while AWT still believes it is on RIGHT_SCREEN.
+        final Rectangle frameBounds = new Rectangle(2240, 180, 1920, 1080);
+        final Rectangle nativeBounds = new Rectangle(5120, 0, 1920, 1080);
+
+        assertThat(ApplicationViewController.needsNormalWindowResynchronization(
+            true, Frame.NORMAL, frameBounds, nativeBounds)).isTrue();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_withMatchingBounds_returnsFalse() {
+        final Rectangle frameBounds = new Rectangle(5120, 0, 1920, 1080);
+
+        assertThat(ApplicationViewController.needsNormalWindowResynchronization(
+            true, Frame.NORMAL, frameBounds, new Rectangle(frameBounds))).isFalse();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_withSizeMismatch_returnsFalse() {
+        // A size difference means the window manager is still placing the window.
+        // Acting on transient geometry must be avoided.
+        final Rectangle frameBounds = new Rectangle(5120, 0, 1920, 1080);
+
+        assertThat(ApplicationViewController.needsNormalWindowResynchronization(
+            true, Frame.NORMAL, frameBounds, new Rectangle(5120, 0, 1912, 1040))).isFalse();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_whenMaximized_returnsFalse() {
+        final Rectangle frameBounds = new Rectangle(2240, 180, 1920, 1080);
+
+        assertThat(ApplicationViewController.needsNormalWindowResynchronization(
+            true, Frame.MAXIMIZED_BOTH, frameBounds, new Rectangle(5120, 0, 1920, 1080))).isFalse();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_whenIconified_returnsFalse() {
+        final Rectangle frameBounds = new Rectangle(2240, 180, 1920, 1080);
+
+        assertThat(ApplicationViewController.needsNormalWindowResynchronization(
+            true, Frame.NORMAL | Frame.ICONIFIED, frameBounds, new Rectangle(5120, 0, 1920, 1080))).isFalse();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_withNonX11Toolkit_returnsFalse() {
+        final Rectangle frameBounds = new Rectangle(2240, 180, 1920, 1080);
+
+        assertThat(ApplicationViewController.needsNormalWindowResynchronization(
+            false, Frame.NORMAL, frameBounds, new Rectangle(5120, 0, 1920, 1080))).isFalse();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_withMissingBounds_returnsFalse() {
+        assertThat(ApplicationViewController.needsNormalWindowResynchronization(
+            true, Frame.NORMAL, null, new Rectangle(5120, 0, 1920, 1080))).isFalse();
+        assertThat(ApplicationViewController.needsNormalWindowResynchronization(
+            true, Frame.NORMAL, new Rectangle(2240, 180, 1920, 1080), null)).isFalse();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_withSmallCoordinateDifference_returnsFalse() {
+        final Rectangle frameBounds = new Rectangle(5119, 1, 1920, 1080);
+
+        assertThat(ApplicationViewController.needsNormalWindowResynchronization(
+            true, Frame.NORMAL, frameBounds, new Rectangle(5120, 0, 1920, 1080))).isFalse();
+    }
+
+    @Test
+    public void findTargetScreenBounds_returnsScreenWithLargestFrameIntersection() {
+        final Rectangle normalBounds = new Rectangle(5270, 84, 1608, 940);
+
+        assertThat(ApplicationViewController.findTargetScreenBounds(normalBounds,
+            new Rectangle[] { LEFT_SCREEN, PRIMARY_SCREEN, RIGHT_SCREEN })).isEqualTo(RIGHT_SCREEN);
+    }
+
+    @Test
+    public void findTargetScreenBounds_prefersScreenContainingMostOfCrossingFrame() {
+        final Rectangle normalBounds = new Rectangle(1800, 100, 1600, 900);
+
+        assertThat(ApplicationViewController.findTargetScreenBounds(normalBounds,
+            new Rectangle[] { LEFT_SCREEN, PRIMARY_SCREEN, RIGHT_SCREEN })).isEqualTo(PRIMARY_SCREEN);
+    }
+
+    @Test
+    public void findTargetScreenBounds_withMissingOrDisjointBounds_returnsNull() {
+        assertThat(ApplicationViewController.findTargetScreenBounds(null,
+            new Rectangle[] { LEFT_SCREEN })).isNull();
+        assertThat(ApplicationViewController.findTargetScreenBounds(new Rectangle(3000, 100, 100, 100),
+            new Rectangle[] { LEFT_SCREEN, PRIMARY_SCREEN, RIGHT_SCREEN })).isNull();
+    }
+
+    @Test
+    public void findTargetScreenBounds_ignoresMissingScreenBounds() {
+        final Rectangle normalBounds = new Rectangle(5270, 84, 1608, 940);
+
+        assertThat(ApplicationViewController.findTargetScreenBounds(normalBounds,
+            new Rectangle[] { null, RIGHT_SCREEN })).isEqualTo(RIGHT_SCREEN);
+    }
 
     @Test
     public void needsFrameResynchronization_withStaleNormalX11FrameLocation_returnsTrue() {

--- a/freeplane/src/viewer/resources/freeplane.properties
+++ b/freeplane/src/viewer/resources/freeplane.properties
@@ -848,4 +848,3 @@ showStatusBarOnError=true
 # 'flatlaf': Forces FlatPopupFactory when FlatLaf is active.
 # 'basic': Forces standard Swing PopupFactory (fallback if custom window managers encounter issues).
 freeplane.popup_factory=auto
-

--- a/freeplane/src/viewer/resources/freeplane.properties
+++ b/freeplane/src/viewer/resources/freeplane.properties
@@ -842,3 +842,10 @@ outputs_status_message_after_automatic_save=true
 outlineFilterHistorySize=10
 outlineTextWritingDirection=LEFT_TO_RIGHT
 showStatusBarOnError=true
+
+# Popup factory strategy: 'auto' (recommended), 'flatlaf', or 'basic'
+# 'auto': Uses multi-monitor-aware FlatPopupFactory for FlatLaf themes with JBR compatibility adjustments.
+# 'flatlaf': Forces FlatPopupFactory when FlatLaf is active.
+# 'basic': Forces standard Swing PopupFactory (fallback if custom window managers encounter issues).
+freeplane.popup_factory=auto
+


### PR DESCRIPTION
## Problem

Freeplane popups (menu bar popups, combo-box drop-downs, context menus, tooltips) are misplaced on multi-monitor setups with mixed resolutions/scales, and on Linux/X11 (Java 11 + KWin) the whole frame's coordinate cache can desync from the window manager so popups appear on the wrong monitor. Two distinct defects:

1. `FrameController` unconditionally replaced FlatLaf's multi-monitor-aware `FlatPopupFactory` with Swing's basic `PopupFactory`, which recycles heavyweight popup windows without checking their `GraphicsConfiguration`, so recycled popups render on the monitor/scale of the window they were first created on.
2. On OpenJDK 11 under X11 with KWin, AWT's top-level window position cache does not update (fully or partially) when the window manager places, maximizes, restores, or moves the window, while the visible native window is elsewhere. Popups anchor to the stale AWT coordinates.

## Changes

**Cross-platform popup factory (all OS)**
- `FrameController`: stop discarding `FlatPopupFactory`; add `configurePopupFactory()` invoked from `fixLookAndFeelUI()` so it is authoritative on startup and on every look-and-feel change.
- New preference `freeplane.popup_factory=auto|flatlaf|basic` (default `auto`) with an explicit fallback for users.
- `Compat.isJetBrainsRuntime()` detection: on JetBrains Runtime, `auto` disables `Popup.dropShadowPainted` (the original reason the factory had been disabled); `basic` remains an escape hatch.

**X11 frame coordinate resynchronization (X11 toolkit only)**
- `ApplicationViewController.FrameResynchronizer`: resynchronize the frame with the window manager geometry on open, maximize transitions, unmaximize restore, and normal-state move/resize events.
- Native geometry is derived from the X11 shell window (`XTranslateCoordinates` + `XGetGeometry`) plus `_NET_FRAME_EXTENTS` via the already bundled JNA (`jna-platform`), converted to logical pixels and guarded by a plausibility check.
- The native position is only adopted when window sizes agree (transient window-manager geometry is never applied); a bounded deferred recheck (10 x 200 ms) covers delayed AWT configure notifications and window-manager animations.
- All native handling is gated on `sun.awt.X11.XToolkit`; Windows, macOS and native-Wayland toolkits are unaffected.

## Testing

- New unit tests: `ApplicationViewControllerTest` (screen-target selection, maximize/unmaximize/normal-window resync conditions — including the stale-position-versus-native-size cases), `PopupFactoryConfigurationTest` (factory selection, L&F transitions, preference overrides), `CompatTest` (JetBrains Runtime detection).
- `gradle :freeplane:test` passes (all suites).
- Manually verified on a 3-monitor X11/KWin setup (1920x1080 + 3200x1800 + 1920x1080, Java 11): startup-maximized on a secondary monitor, cross-monitor moves, maximize/restore cycles, and popup placement all keep AWT coordinates equal to the native window geometry (popup anchor == visible window).
