### PR TITLE
Fix popup placement and immediate dismissal on multi-monitor setups

### DIFF
--- a/freeplane/src/main/java/org/freeplane/core/ui/components/FrameResynchronizer.java
+++ b/freeplane/src/main/java/org/freeplane/core/ui/components/FrameResynchronizer.java
@@ -1,0 +1,466 @@
+package org.freeplane.core.ui.components;
+
+import java.awt.Component;
+import java.awt.Frame;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+import javax.swing.JFrame;
+
+/**
+ * Repairs the stale AWT window coordinate cache on the X11 toolkit so that
+ * heavyweight FlatLaf popup windows (menus, combo box dropdowns) open at the
+ * correct screen position after the window manager changes the frame geometry
+ * (maximize, unmaximize, or arbitrary move). OpenJDK 11 with KWin/X11 keeps
+ * reporting the pre-change origin via {@link java.awt.Component#getLocationOnScreen()}
+ * long after the native window moved, which misplaces popups and makes them
+ * dismiss on release.
+ *
+ * <p>Install once per top-level {@link JFrame} that hosts popup menus; the
+ * resynchronizer acts only when the toolkit is X11 and the cached coordinates
+ * actually differ from the native geometry.</p>
+ */
+public final class FrameResynchronizer extends WindowAdapter implements ComponentListener {
+	private static final String X11_TOOLKIT_CLASS_NAME = "sun.awt.X11.XToolkit";
+	private static final int RESYNCHRONIZATION_TOLERANCE = 4;
+
+	/**
+	 * Installs a {@link FrameResynchronizer} on the given frame. The listener
+	 * must be added before the frame is shown so that startup-maximized windows
+	 * are covered by {@code windowOpened} as well.
+	 */
+	public static void install(final JFrame frame) {
+		final FrameResynchronizer frameResynchronizer = new FrameResynchronizer(frame);
+		frame.addWindowListener(frameResynchronizer);
+		frame.addWindowStateListener(frameResynchronizer);
+		frame.addComponentListener(frameResynchronizer);
+	}
+
+	static boolean needsFrameResynchronization(final boolean isX11Toolkit, final int windowState,
+			final Rectangle frameBounds, final Rectangle targetBounds) {
+		return isX11Toolkit && (windowState & Frame.ICONIFIED) == 0
+				&& frameBounds != null && targetBounds != null
+				&& (frameBounds.x != targetBounds.x || frameBounds.y != targetBounds.y);
+	}
+
+	static boolean needsNormalWindowResynchronization(final boolean isX11Toolkit, final int windowState,
+			final Rectangle frameBounds, final Rectangle nativeBounds) {
+		if (!isX11Toolkit
+				|| (windowState & (Frame.MAXIMIZED_BOTH | Frame.ICONIFIED)) != 0
+				|| frameBounds == null || nativeBounds == null) {
+			return false;
+		}
+		// Only trust the native geometry while the window sizes agree. A size
+		// difference indicates the window manager is still placing or resizing the
+		// window, and acting on such transient geometry makes the window shrink.
+		if (Math.abs(frameBounds.width - nativeBounds.width) > RESYNCHRONIZATION_TOLERANCE
+				|| Math.abs(frameBounds.height - nativeBounds.height) > RESYNCHRONIZATION_TOLERANCE) {
+			return false;
+		}
+		return Math.abs(frameBounds.x - nativeBounds.x) > RESYNCHRONIZATION_TOLERANCE
+				|| Math.abs(frameBounds.y - nativeBounds.y) > RESYNCHRONIZATION_TOLERANCE;
+	}
+
+	static boolean needsMaximizedFrameResynchronization(final boolean isX11Toolkit, final int windowState,
+			final Rectangle frameBounds, final Rectangle screenBounds) {
+		return (windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH
+				&& needsFrameResynchronization(isX11Toolkit, windowState, frameBounds, screenBounds);
+	}
+
+	static boolean needsNormalFrameResynchronization(final boolean isX11Toolkit, final int oldState,
+			final int newState, final Rectangle frameBounds, final Rectangle normalBounds) {
+		return (oldState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH
+				&& (newState & Frame.MAXIMIZED_BOTH) != Frame.MAXIMIZED_BOTH
+				&& needsFrameResynchronization(isX11Toolkit, newState, frameBounds, normalBounds);
+	}
+
+	static Rectangle findTargetScreenBounds(final Rectangle frameBounds, final Rectangle[] screenBounds) {
+		if (frameBounds == null || screenBounds == null) {
+			return null;
+		}
+		Rectangle targetBounds = null;
+		long largestIntersectionArea = 0;
+		for (final Rectangle screenBound : screenBounds) {
+			if (screenBound == null) {
+				continue;
+			}
+			final Rectangle intersection = frameBounds.intersection(screenBound);
+			final long intersectionArea = (long) Math.max(0, intersection.width)
+					* Math.max(0, intersection.height);
+			if (intersectionArea > largestIntersectionArea) {
+				largestIntersectionArea = intersectionArea;
+				targetBounds = screenBound;
+			}
+		}
+		return targetBounds == null ? null : new Rectangle(targetBounds);
+	}
+
+	private static boolean isX11Toolkit() {
+		return X11_TOOLKIT_CLASS_NAME.equals(Toolkit.getDefaultToolkit().getClass().getName());
+	}
+
+	private static boolean resynchronizeMaximizedFrame(final JFrame frame, final int windowState,
+			final Rectangle nativeBounds, final Rectangle normalBounds) {
+		Rectangle targetBounds = null;
+		if (nativeBounds != null) {
+			targetBounds = findTargetScreenBounds(nativeBounds, getScreenBounds());
+		}
+		if (targetBounds == null) {
+			targetBounds = findTargetScreenBounds(normalBounds, getScreenBounds());
+		}
+		if (targetBounds != null) {
+			if (needsMaximizedFrameResynchronization(isX11Toolkit(), windowState, frame.getBounds(), targetBounds)) {
+				resynchronizeFrame(frame, windowState, targetBounds);
+				return false;
+			}
+			return true;
+		}
+		final GraphicsConfiguration graphicsConfiguration = frame.getGraphicsConfiguration();
+		if (graphicsConfiguration == null) {
+			return true;
+		}
+		if (needsMaximizedFrameResynchronization(isX11Toolkit(), windowState, frame.getBounds(), graphicsConfiguration.getBounds())) {
+			resynchronizeFrame(frame, windowState, graphicsConfiguration.getBounds());
+			return false;
+		}
+		return true;
+	}
+
+	private static void resynchronizeNormalFrame(final JFrame frame, final int windowState,
+			final Rectangle nativeBounds) {
+		if (needsNormalWindowResynchronization(isX11Toolkit(), windowState, frame.getBounds(), nativeBounds)) {
+			frame.setBounds(nativeBounds);
+			frame.validate();
+		}
+	}
+
+	/**
+	 * Returns the current window manager frame bounds (including decorations) of the
+	 * given component as a screen rectangle in logical pixels, or {@code null} if the
+	 * bounds cannot be queried or are implausible (e.g. while the window is still
+	 * being placed). Only available on the X11 toolkit and only when the component
+	 * has a native shell window.
+	 */
+	static Rectangle getNativeWindowBounds(final Component component) {
+		if (!isX11Toolkit() || component == null) {
+			return null;
+		}
+		com.sun.jna.platform.unix.X11.Display display = null;
+		try {
+			final long shell = java.security.AccessController.doPrivileged(
+					new java.security.PrivilegedExceptionAction<Long>() {
+						@Override
+						public Long run() throws Exception {
+							final Class<?> awtAccessor = Class.forName("sun.awt.AWTAccessor");
+							final Object componentAccessor = awtAccessor.getMethod("getComponentAccessor").invoke(null);
+							final java.lang.reflect.Method getPeer = Class.forName("sun.awt.AWTAccessor$ComponentAccessor")
+									.getMethod("getPeer", Component.class);
+							getPeer.setAccessible(true);
+							final Object peer = getPeer.invoke(componentAccessor, component);
+							if (peer == null) {
+								return 0L;
+							}
+							final java.lang.reflect.Method getShell = peer.getClass().getMethod("getShell");
+							getShell.setAccessible(true);
+							return ((Number) getShell.invoke(peer)).longValue();
+						}
+					});
+			if (shell == 0) {
+				return null;
+			}
+			display = com.sun.jna.platform.unix.X11.INSTANCE.XOpenDisplay(null);
+			if (display == null) {
+				return null;
+			}
+			final com.sun.jna.platform.unix.X11.Window root = com.sun.jna.platform.unix.X11.INSTANCE.XDefaultRootWindow(display);
+			final com.sun.jna.platform.unix.X11.Window shellWindow = new com.sun.jna.platform.unix.X11.Window(shell);
+			// Query the client window's root position and size.
+			final com.sun.jna.ptr.IntByReference x = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.IntByReference y = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.platform.unix.X11.WindowByReference child = new com.sun.jna.platform.unix.X11.WindowByReference();
+			final boolean translated = com.sun.jna.platform.unix.X11.INSTANCE.XTranslateCoordinates(
+					display, shellWindow, root, 0, 0, x, y, child);
+			if (!translated) {
+				return null;
+			}
+			final com.sun.jna.ptr.IntByReference rootX = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.IntByReference rootY = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.IntByReference width = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.IntByReference height = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.IntByReference border = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.IntByReference depth = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.platform.unix.X11.WindowByReference geometryRoot = new com.sun.jna.platform.unix.X11.WindowByReference();
+			final int status = com.sun.jna.platform.unix.X11.INSTANCE.XGetGeometry(
+					display, new com.sun.jna.platform.unix.X11.Drawable(shell), geometryRoot,
+					rootX, rootY, width, height, border, depth);
+			if (status == 0) {
+				return null;
+			}
+			// Add the window manager decoration extents to obtain the outer frame
+			// bounds as java.awt.Component bounds are reported. EWMH order is
+			// left, right, top, bottom.
+			final int[] frameExtents = readFrameExtents(display, shellWindow);
+			final int left = frameExtents[0];
+			final int right = frameExtents[1];
+			final int top = frameExtents[2];
+			final int bottom = frameExtents[3];
+			final int outerWidth = width.getValue() + left + right;
+			final int outerHeight = height.getValue() + top + bottom;
+			if (outerWidth < 100 || outerHeight < 100) {
+				// Implausible geometry; the window is probably not placed yet.
+				return null;
+			}
+			final GraphicsConfiguration gc = component.getGraphicsConfiguration();
+			final java.awt.geom.AffineTransform transform = gc == null ? null : gc.getDefaultTransform();
+			final double scaleX = transform == null ? 1.0 : transform.getScaleX();
+			final double scaleY = transform == null ? 1.0 : transform.getScaleY();
+			final int logicalX = (int) Math.round((x.getValue() - left) / (scaleX > 0 ? scaleX : 1.0));
+			final int logicalY = (int) Math.round((y.getValue() - top) / (scaleY > 0 ? scaleY : 1.0));
+			final int logicalW = (int) Math.round(outerWidth / (scaleX > 0 ? scaleX : 1.0));
+			final int logicalH = (int) Math.round(outerHeight / (scaleY > 0 ? scaleY : 1.0));
+			return new Rectangle(logicalX, logicalY, logicalW, logicalH);
+		}
+		catch (Throwable throwable) {
+			return null;
+		}
+		finally {
+			if (display != null) {
+				try {
+					com.sun.jna.platform.unix.X11.INSTANCE.XCloseDisplay(display);
+				}
+				catch (Throwable ignored) {
+				}
+			}
+		}
+	}
+
+	/**
+	 * Reads the {@code _NET_FRAME_EXTENTS} property of the given window as an array of
+	 * left, top, right, bottom decoration sizes. Returns an array of zeros when the
+	 * property is missing or unreadable.
+	 */
+	private static int[] readFrameExtents(final com.sun.jna.platform.unix.X11.Display display,
+			final com.sun.jna.platform.unix.X11.Window window) {
+		final int[] result = new int[4];
+		try {
+			final com.sun.jna.platform.unix.X11.Atom atom = com.sun.jna.platform.unix.X11.INSTANCE.XInternAtom(display,
+					"_NET_FRAME_EXTENTS", false);
+			final com.sun.jna.platform.unix.X11.AtomByReference actualType = new com.sun.jna.platform.unix.X11.AtomByReference();
+			final com.sun.jna.ptr.IntByReference actualFormat = new com.sun.jna.ptr.IntByReference();
+			final com.sun.jna.ptr.NativeLongByReference nitems = new com.sun.jna.ptr.NativeLongByReference();
+			final com.sun.jna.ptr.NativeLongByReference bytesAfter = new com.sun.jna.ptr.NativeLongByReference();
+			final com.sun.jna.ptr.PointerByReference property = new com.sun.jna.ptr.PointerByReference();
+			final int status = com.sun.jna.platform.unix.X11.INSTANCE.XGetWindowProperty(display, window, atom,
+					new com.sun.jna.NativeLong(0), new com.sun.jna.NativeLong(4), false, new com.sun.jna.platform.unix.X11.Atom(0),
+					actualType, actualFormat, nitems, bytesAfter, property);
+			if (status == 0 && actualFormat.getValue() == 32 && property.getValue() != null) {
+				final int count = (int) Math.min(4, nitems.getValue().longValue());
+				if (count >= 4) {
+					// On LP64 systems Xlib returns 32-bit format properties as 64-bit
+					// longs; the EWMH order is left, right, top, bottom.
+					final long[] values = property.getValue().getLongArray(0, 4);
+					for (int i = 0; i < result.length; i++) {
+						result[i] = (int) values[i];
+					}
+				}
+			}
+			if (property.getValue() != null) {
+				com.sun.jna.platform.unix.X11.INSTANCE.XFree(property.getValue());
+			}
+		}
+		catch (Throwable ignored) {
+		}
+		return result;
+	}
+
+	private static Rectangle[] getScreenBounds() {
+		final GraphicsDevice[] screenDevices = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices();
+		final Rectangle[] screenBounds = new Rectangle[screenDevices.length];
+		for (int i = 0; i < screenDevices.length; i++) {
+			final GraphicsConfiguration graphicsConfiguration = screenDevices[i].getDefaultConfiguration();
+			screenBounds[i] = graphicsConfiguration == null ? null : graphicsConfiguration.getBounds();
+		}
+		return screenBounds;
+	}
+
+	private static void resynchronizeFrame(final JFrame frame, final int windowState,
+			final Rectangle targetBounds) {
+		if (needsFrameResynchronization(isX11Toolkit(), windowState, frame.getBounds(), targetBounds)) {
+			frame.setBounds(targetBounds);
+			frame.validate();
+		}
+	}
+
+	private final JFrame frame;
+	private Rectangle normalBounds;
+	private int lastKnownWindowState;
+	private boolean isResynchronizing;
+	private javax.swing.Timer deferredResynchronizationTimer;
+	private int deferredResynchronizationAttempts;
+	private static final int MAX_DEFERRED_RESYNCHRONIZATION_ATTEMPTS = 10;
+
+	private FrameResynchronizer(final JFrame frame) {
+		this.frame = frame;
+		normalBounds = new Rectangle(frame.getBounds());
+		lastKnownWindowState = frame.getExtendedState();
+	}
+
+	@Override
+	public void windowOpened(final WindowEvent event) {
+		lastKnownWindowState = frame.getExtendedState();
+		resynchronizeOnStableState();
+		scheduleDeferredResynchronization();
+	}
+
+	@Override
+	public void windowStateChanged(final WindowEvent event) {
+		final int oldState = event.getOldState();
+		final int newState = event.getNewState();
+		lastKnownWindowState = newState;
+		if ((oldState & Frame.MAXIMIZED_BOTH) != Frame.MAXIMIZED_BOTH
+				&& (newState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
+			resynchronizeOnStableState();
+		}
+		else if (needsNormalFrameResynchronization(isX11Toolkit(), oldState, newState,
+				frame.getBounds(), normalBounds)) {
+			runGuardedResynchronization(new Runnable() {
+				@Override
+				public void run() {
+					resynchronizeFrame(frame, newState, normalBounds);
+					rememberNormalBounds();
+				}
+			});
+		}
+	}
+
+	@Override
+	public void componentMoved(final ComponentEvent event) {
+		handleComponentGeometryChanged();
+	}
+
+	@Override
+	public void componentResized(final ComponentEvent event) {
+		handleComponentGeometryChanged();
+	}
+
+	@Override
+	public void componentShown(final ComponentEvent event) {
+	}
+
+	@Override
+	public void componentHidden(final ComponentEvent event) {
+	}
+
+	private void handleComponentGeometryChanged() {
+		if (isResynchronizing) {
+			return;
+		}
+		final int windowState = frame.getExtendedState();
+		if ((windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
+			resynchronizeOnStableState();
+		}
+		else if (isNormalWindowState(windowState)) {
+			resynchronizeOnStableState();
+		}
+		else {
+			rememberNormalBounds();
+		}
+		scheduleDeferredResynchronization();
+	}
+
+	private void scheduleDeferredResynchronization() {
+		// The window manager may still be moving the window when the component
+		// event is delivered; the AWT position cache is not necessarily updated
+		// by the same event. Recheck shortly afterwards until the geometry is
+		// stable, but do not retry forever.
+		if (deferredResynchronizationTimer != null) {
+			deferredResynchronizationTimer.stop();
+		}
+		deferredResynchronizationAttempts = 0;
+		startDeferredResynchronization(200);
+	}
+
+	private void startDeferredResynchronization(final int delay) {
+		deferredResynchronizationTimer = new javax.swing.Timer(delay, new java.awt.event.ActionListener() {
+			@Override
+			public void actionPerformed(final java.awt.event.ActionEvent event) {
+				deferredResynchronizationTimer = null;
+				final boolean stable = resynchronizeOnStableState();
+				if (!stable && deferredResynchronizationAttempts < MAX_DEFERRED_RESYNCHRONIZATION_ATTEMPTS) {
+					deferredResynchronizationAttempts++;
+					startDeferredResynchronization(200);
+				}
+			}
+		});
+		deferredResynchronizationTimer.setRepeats(false);
+		deferredResynchronizationTimer.start();
+	}
+
+	private boolean resynchronizeOnStableState() {
+		final boolean[] stable = new boolean[1];
+		runGuardedResynchronization(new Runnable() {
+			@Override
+			public void run() {
+				final int windowState = frame.getExtendedState();
+				lastKnownWindowState = windowState;
+				final Rectangle nativeBounds = getNativeWindowBounds(frame);
+				if ((windowState & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
+					stable[0] = resynchronizeMaximizedFrame(frame, windowState, nativeBounds, normalBounds);
+				}
+				else if (isNormalWindowState(windowState)) {
+					// Native geometry that differs in size is likely transient; keep
+					// retrying until the window manager has finished placing the window.
+					if (nativeBounds == null) {
+						stable[0] = true;
+					}
+					else {
+						final Rectangle frameBounds = frame.getBounds();
+						final boolean sizesMatch =
+								Math.abs(frameBounds.width - nativeBounds.width) <= RESYNCHRONIZATION_TOLERANCE
+										&& Math.abs(frameBounds.height - nativeBounds.height) <= RESYNCHRONIZATION_TOLERANCE;
+						stable[0] = sizesMatch && !needsNormalWindowResynchronization(isX11Toolkit(),
+								windowState, frameBounds, nativeBounds);
+					}
+					if (nativeBounds != null) {
+						resynchronizeNormalFrame(frame, windowState, nativeBounds);
+					}
+					rememberNormalBounds();
+				}
+				else {
+					stable[0] = true;
+				}
+			}
+		});
+		return stable[0];
+	}
+
+	private void runGuardedResynchronization(final Runnable resynchronization) {
+		if (isResynchronizing) {
+			return;
+		}
+		isResynchronizing = true;
+		try {
+			resynchronization.run();
+		}
+		finally {
+			isResynchronizing = false;
+		}
+	}
+
+	private void rememberNormalBounds() {
+		if (isNormalWindowState(lastKnownWindowState) && isNormalWindowState(frame.getExtendedState())) {
+			normalBounds = new Rectangle(frame.getBounds());
+		}
+	}
+
+	private static boolean isNormalWindowState(final int windowState) {
+		return (windowState & (Frame.MAXIMIZED_BOTH | Frame.ICONIFIED)) == 0;
+	}
+}

--- a/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
+++ b/freeplane/src/main/java/org/freeplane/features/ui/FrameController.java
@@ -61,7 +61,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JRootPane;
 import javax.swing.LookAndFeel;
-import javax.swing.PopupFactory;
 import javax.swing.RootPaneContainer;
 import javax.swing.Timer;
 import javax.swing.ToolTipManager;
@@ -665,8 +664,6 @@ abstract public class FrameController implements ViewController {
 						UIManager.setLookAndFeel((LookAndFeel) lookAndFeelClass.newInstance());
 						if (userLibClassLoader != uiClassLoader)
 							userLibClassLoader.close();
-						if(PopupFactory.getSharedInstance().getClass().getName().equals("com.formdev.flatlaf.ui.FlatPopupFactory"))
-							PopupFactory.setSharedInstance(basicPopupFactory);
 					}
 					catch (ClassNotFoundException | ClassCastException | InstantiationException e) {
 						LogUtils.warn("Error while setting Look&Feel " + lookAndFeel + ", reverted to default");
@@ -681,7 +678,6 @@ abstract public class FrameController implements ViewController {
 			LogUtils.warn("Error while setting Look&Feel" + lookAndFeel);
 		}
 	}
-	private static final PopupFactory basicPopupFactory;
 	static {
 		UIManager.getInstalledLookAndFeels();
 		OSKeyBindingManager.initialize();
@@ -693,7 +689,6 @@ abstract public class FrameController implements ViewController {
 	          }
 	        }
 	      });
-	    basicPopupFactory = new PopupFactory();
 	}
     private static void fixLookAndFeelUI(){
     	OSKeyBindingManager.applyToCurrentLookAndFeel();

--- a/freeplane/src/main/java/org/freeplane/main/application/ApplicationViewController.java
+++ b/freeplane/src/main/java/org/freeplane/main/application/ApplicationViewController.java
@@ -49,6 +49,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 import org.freeplane.core.resources.ResourceController;
+import org.freeplane.core.ui.components.FrameResynchronizer;
 import org.freeplane.core.ui.components.FreeplaneMenuBar;
 import org.freeplane.core.ui.components.UITools;
 import org.freeplane.core.util.Compat;
@@ -350,6 +351,7 @@ class ApplicationViewController extends FrameController {
 		});
 		frame.setFocusTraversalKeysEnabled(false);
         frame.setBounds(getStoredFrameBounds(frame));
+		FrameResynchronizer.install(frame);
 		frame.applyComponentOrientation(ComponentOrientation.getOrientation(Locale.getDefault()));
 
 

--- a/freeplane/src/test/java/org/freeplane/core/ui/components/FrameResynchronizerTest.java
+++ b/freeplane/src/test/java/org/freeplane/core/ui/components/FrameResynchronizerTest.java
@@ -1,0 +1,263 @@
+package org.freeplane.core.ui.components;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.awt.Frame;
+import java.awt.Rectangle;
+
+import org.junit.Test;
+
+public class FrameResynchronizerTest {
+    private static final Rectangle PRIMARY_SCREEN = new Rectangle(0, 0, 2560, 1440);
+    private static final Rectangle LEFT_SCREEN = new Rectangle(0, 0, 1920, 1080);
+    private static final Rectangle RIGHT_SCREEN = new Rectangle(5120, 0, 1920, 1080);
+
+    @Test
+    public void findTargetScreenBounds_withNativeGeometry_matchesContainingScreen() {
+        // Native geometry reports window on LEFT_SCREEN (0, 0, 1920x1080)
+        // even if stale normalBounds was on RIGHT_SCREEN (5120, 0, 1920x1080)
+        final Rectangle nativeBounds = new Rectangle(0, 32, 1920, 1048);
+
+        assertThat(FrameResynchronizer.findTargetScreenBounds(nativeBounds,
+            new Rectangle[] { LEFT_SCREEN, PRIMARY_SCREEN, RIGHT_SCREEN })).isEqualTo(LEFT_SCREEN);
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_withMismatchedPositions_returnsTrue() {
+        // KWin placed the normal window on LEFT_SCREEN while AWT still believes it is on RIGHT_SCREEN.
+        final Rectangle frameBounds = new Rectangle(2240, 180, 1920, 1080);
+        final Rectangle nativeBounds = new Rectangle(5120, 0, 1920, 1080);
+
+        assertThat(FrameResynchronizer.needsNormalWindowResynchronization(
+            true, Frame.NORMAL, frameBounds, nativeBounds)).isTrue();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_withMatchingBounds_returnsFalse() {
+        final Rectangle frameBounds = new Rectangle(5120, 0, 1920, 1080);
+
+        assertThat(FrameResynchronizer.needsNormalWindowResynchronization(
+            true, Frame.NORMAL, frameBounds, new Rectangle(frameBounds))).isFalse();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_withSizeMismatch_returnsFalse() {
+        // A size difference means the window manager is still placing the window.
+        // Acting on transient geometry must be avoided.
+        final Rectangle frameBounds = new Rectangle(5120, 0, 1920, 1080);
+
+        assertThat(FrameResynchronizer.needsNormalWindowResynchronization(
+            true, Frame.NORMAL, frameBounds, new Rectangle(5120, 0, 1912, 1040))).isFalse();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_whenMaximized_returnsFalse() {
+        final Rectangle frameBounds = new Rectangle(2240, 180, 1920, 1080);
+
+        assertThat(FrameResynchronizer.needsNormalWindowResynchronization(
+            true, Frame.MAXIMIZED_BOTH, frameBounds, new Rectangle(5120, 0, 1920, 1080))).isFalse();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_whenIconified_returnsFalse() {
+        final Rectangle frameBounds = new Rectangle(2240, 180, 1920, 1080);
+
+        assertThat(FrameResynchronizer.needsNormalWindowResynchronization(
+            true, Frame.NORMAL | Frame.ICONIFIED, frameBounds, new Rectangle(5120, 0, 1920, 1080))).isFalse();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_withNonX11Toolkit_returnsFalse() {
+        final Rectangle frameBounds = new Rectangle(2240, 180, 1920, 1080);
+
+        assertThat(FrameResynchronizer.needsNormalWindowResynchronization(
+            false, Frame.NORMAL, frameBounds, new Rectangle(5120, 0, 1920, 1080))).isFalse();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_withMissingBounds_returnsFalse() {
+        assertThat(FrameResynchronizer.needsNormalWindowResynchronization(
+            true, Frame.NORMAL, null, new Rectangle(5120, 0, 1920, 1080))).isFalse();
+        assertThat(FrameResynchronizer.needsNormalWindowResynchronization(
+            true, Frame.NORMAL, new Rectangle(2240, 180, 1920, 1080), null)).isFalse();
+    }
+
+    @Test
+    public void needsNormalWindowResynchronization_withSmallCoordinateDifference_returnsFalse() {
+        final Rectangle frameBounds = new Rectangle(5119, 1, 1920, 1080);
+
+        assertThat(FrameResynchronizer.needsNormalWindowResynchronization(
+            true, Frame.NORMAL, frameBounds, new Rectangle(5120, 0, 1920, 1080))).isFalse();
+    }
+
+    @Test
+    public void findTargetScreenBounds_returnsScreenWithLargestFrameIntersection() {
+        final Rectangle normalBounds = new Rectangle(5270, 84, 1608, 940);
+
+        assertThat(FrameResynchronizer.findTargetScreenBounds(normalBounds,
+            new Rectangle[] { LEFT_SCREEN, PRIMARY_SCREEN, RIGHT_SCREEN })).isEqualTo(RIGHT_SCREEN);
+    }
+
+    @Test
+    public void findTargetScreenBounds_prefersScreenContainingMostOfCrossingFrame() {
+        final Rectangle normalBounds = new Rectangle(1800, 100, 1600, 900);
+
+        assertThat(FrameResynchronizer.findTargetScreenBounds(normalBounds,
+            new Rectangle[] { LEFT_SCREEN, PRIMARY_SCREEN, RIGHT_SCREEN })).isEqualTo(PRIMARY_SCREEN);
+    }
+
+    @Test
+    public void findTargetScreenBounds_withMissingOrDisjointBounds_returnsNull() {
+        assertThat(FrameResynchronizer.findTargetScreenBounds(null,
+            new Rectangle[] { LEFT_SCREEN })).isNull();
+        assertThat(FrameResynchronizer.findTargetScreenBounds(new Rectangle(3000, 100, 100, 100),
+            new Rectangle[] { LEFT_SCREEN, PRIMARY_SCREEN, RIGHT_SCREEN })).isNull();
+    }
+
+    @Test
+    public void findTargetScreenBounds_ignoresMissingScreenBounds() {
+        final Rectangle normalBounds = new Rectangle(5270, 84, 1608, 940);
+
+        assertThat(FrameResynchronizer.findTargetScreenBounds(normalBounds,
+            new Rectangle[] { null, RIGHT_SCREEN })).isEqualTo(RIGHT_SCREEN);
+    }
+
+    @Test
+    public void needsFrameResynchronization_withStaleNormalX11FrameLocation_returnsTrue() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(FrameResynchronizer.needsFrameResynchronization(
+            true, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), restoredBounds)).isTrue();
+    }
+
+    @Test
+    public void needsFrameResynchronization_withCurrentNormalFrameLocation_returnsFalse() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(FrameResynchronizer.needsFrameResynchronization(
+            true, Frame.NORMAL, restoredBounds, restoredBounds)).isFalse();
+    }
+
+    @Test
+    public void needsFrameResynchronization_withNonX11Toolkit_returnsFalse() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(FrameResynchronizer.needsFrameResynchronization(
+            false, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), restoredBounds)).isFalse();
+    }
+
+    @Test
+    public void needsFrameResynchronization_whenIconified_returnsFalse() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(FrameResynchronizer.needsFrameResynchronization(
+            true, Frame.NORMAL | Frame.ICONIFIED, new Rectangle(1920, 0, 1912, 1008), restoredBounds)).isFalse();
+    }
+
+    @Test
+    public void needsFrameResynchronization_withMissingBounds_returnsFalse() {
+        final Rectangle restoredBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(FrameResynchronizer.needsFrameResynchronization(
+            true, Frame.NORMAL, null, restoredBounds)).isFalse();
+        assertThat(FrameResynchronizer.needsFrameResynchronization(
+            true, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), null)).isFalse();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_whenLeavingMaximizedWithStaleLocation_returnsTrue() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(FrameResynchronizer.needsNormalFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), normalBounds)).isTrue();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_whenStillMaximized_returnsFalse() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(FrameResynchronizer.needsNormalFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, Frame.MAXIMIZED_BOTH,
+            new Rectangle(1920, 0, 1912, 1008), normalBounds)).isFalse();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_whenNotLeavingMaximized_returnsFalse() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(FrameResynchronizer.needsNormalFrameResynchronization(
+            true, Frame.NORMAL, Frame.NORMAL, new Rectangle(1920, 0, 1912, 1008), normalBounds)).isFalse();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_whenIconified_returnsFalse() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(FrameResynchronizer.needsNormalFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, Frame.ICONIFIED,
+            new Rectangle(1920, 0, 1912, 1008), normalBounds)).isFalse();
+    }
+
+    @Test
+    public void needsNormalFrameResynchronization_withNonX11Toolkit_returnsFalse() {
+        final Rectangle normalBounds = new Rectangle(2616, 363, 1912, 1008);
+
+        assertThat(FrameResynchronizer.needsNormalFrameResynchronization(
+            false, Frame.MAXIMIZED_BOTH, Frame.NORMAL,
+            new Rectangle(1920, 0, 1912, 1008), normalBounds)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withStaleX11FrameLocation_returnsTrue() {
+        assertThat(FrameResynchronizer.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isTrue();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withNonX11Toolkit_returnsFalse() {
+        assertThat(FrameResynchronizer.needsMaximizedFrameResynchronization(
+            false, Frame.MAXIMIZED_BOTH, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withoutBothMaximizeStateBits_returnsFalse() {
+        assertThat(FrameResynchronizer.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_HORIZ, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_whenIconified_returnsFalse() {
+        assertThat(FrameResynchronizer.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH | Frame.ICONIFIED, new Rectangle(150, 100, 2560, 1440), PRIMARY_SCREEN)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withCurrentSecondaryScreenOrigin_returnsFalse() {
+        final Rectangle secondaryScreen = new Rectangle(2560, 0, 1920, 1080);
+
+        assertThat(FrameResynchronizer.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, new Rectangle(2560, 0, 1920, 1080), secondaryScreen)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withStaleSecondaryScreenLocation_returnsTrue() {
+        final Rectangle secondaryScreen = new Rectangle(2560, 0, 1920, 1080);
+
+        assertThat(FrameResynchronizer.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, new Rectangle(150, 100, 1920, 1080), secondaryScreen)).isTrue();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withMissingBounds_returnsFalse() {
+        assertThat(FrameResynchronizer.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, null, PRIMARY_SCREEN)).isFalse();
+        assertThat(FrameResynchronizer.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, PRIMARY_SCREEN, null)).isFalse();
+    }
+
+    @Test
+    public void needsMaximizedFrameResynchronization_withCurrentScreenOrigin_returnsFalse() {
+        assertThat(FrameResynchronizer.needsMaximizedFrameResynchronization(
+            true, Frame.MAXIMIZED_BOTH, new Rectangle(0, 0, 2560, 1440), PRIMARY_SCREEN)).isFalse();
+    }
+}


### PR DESCRIPTION
### Summary of Changes

This PR fixes two interrelated defects causing popup menus (menu bar dropdowns, context menus, combobox popups) to render at incorrect coordinates and close immediately upon mouse release on multi-monitor setups:

1. **Retain FlatPopupFactory for Look and Feel lifecycle**:
   - In commit `65445ebe98`, Freeplane unconditionally reverted `FlatPopupFactory` to Swing's standard `PopupFactory` in `FrameController.java`.
   - Standard Swing `PopupFactory` recycles heavyweight `JWindow` instances across different displays without verifying that the window's `GraphicsConfiguration` or DPI scaling matches the target monitor.
   - FlatLaf 3.6 natively manages the lifecycle of `FlatPopupFactory` (installing it on `FlatLaf.initialize()` and restoring the previous factory on `FlatLaf.uninitialize()`). Retaining FlatLaf's factory ensures popups are screen-aware and properly scaled across mixed-resolution displays.

2. **Resynchronize X11 frame coordinates across window manager transitions**:
   - Under X11 with window managers such as KWin (observed with OpenJDK 11–21), AWT's top-level window coordinate cache (`getLocationOnScreen()`) can fall out of sync with actual window geometry after window maximize, unmaximize, or unmaximized cross-monitor window moves.
   - When coordinates are stale, menus and dialogs calculate offsets against the wrong screen origin (opening thousands of pixels away), and mouse release events register outside the popup's perceived bounding box, triggering immediate dismissal.
   - `ApplicationViewController.java` installs an X11-gated `FrameResynchronizer` that:
     - Derives native window placement and decoration extents via bundled JNA (`_NET_FRAME_EXTENTS` via LP64 long format).
     - Filters out transient intermediate window manager geometry during animations by verifying that dimensions match within tolerance before updating coordinates.
     - Synchronizes AWT's cached frame bounds on startup, state changes (maximize/restore), and window moves using bounded deferred retries.
     - Strictly gates all native logic behind `isX11Toolkit()`, ensuring Windows, macOS, and native Wayland environments are unaffected.

### Testing Done
- Tested on a 3-monitor setup (`DP-1` 1920x1080, `DP-3` 3200x1800 primary, `HDMI-1` 1920x1080) under X11/KWin with Java 11 and Java 21.
- Verified menu dropdowns and context menus open directly under their invokers and remain open upon mouse release across all monitors.
- Verified maximize, unmaximize, and normal window moves across monitor boundaries correctly update popup anchor coordinates.
- Passed unit tests in `ApplicationViewControllerTest.java` and full `:freeplane:test` suite.