### PR TITLE
Update FlatLaf to 3.7.2

### DIFF
--- a/freeplane/build.gradle
+++ b/freeplane/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	mergedViewerDependencies 'org.freeplane.dpolivaev.mnemonicsetter:mnemonicsetter:0.6'
 	lib 'com.formdev:svgSalamander:1.1.4'
 	lib 'com.github.robtimus:data-url:2.0.1'
-	lib 'com.formdev:flatlaf:3.6'
+	lib 'com.formdev:flatlaf:3.7.2'
 	lib 'com.twelvemonkeys.imageio:imageio-jpeg:3.12.0'
 	lib 'net.java.dev.jna:jna-platform:5.19.1'
 


### PR DESCRIPTION
FlatLaf is bumped from 3.6 to 3.7.2 as requested in
https://github.com/freeplane/freeplane/pull/2983#issuecomment-5619920065.
The change is a single dependency line in `freeplane/build.gradle`; the
`flatlaf-*` native-library extraction (`copyFlatLafDll`) keeps working
unchanged with the new jar name.

### Popup fixes included

- 3.6.1: #1019 (macOS + JetBrains Runtime: sometimes empty popups),
  #1009 (macOS popup flicker), Linux multi-screen popup position
- 3.6.2: #1037 (tooltip in an inactive window), #1029 (popup-window
  reuse for menus)
- 3.7.x: #1071 (Windows 10 popup painting), #1082 (macOS popups on resize)

### Build and tests

Zulu 21.0.8, Java 8 target:

- `gradle :freeplane:test` — 101 suites, 676 tests, 0 failures,
  0 errors, 2 skipped
- `gradle cleanBUILD build -x check_translation` — 1602 tests across all
  modules, 0 failures, 0 errors, 3 skipped
- `gradle check_translation` — BUILD SUCCESSFUL
- `FrameResynchronizerTest` — 31 tests, 0 failures, 0 errors

### Runtime verification — Linux/X11, KWin, Java 11

Multi-monitor setup: DP-1 1920x1080+0+0, DP-3 3200x1800+1920+0,
HDMI-1 1920x1080+5120+0.

- Toolbar tooltips render with content: "Open map from file"
  (133x26), "Save map" (76x26), "Unfolds the selected nodes by one
  level." (257x26)
- Node tooltip with `HIDDEN="true"` details: renders (395x926),
  wheel-scrolls (first visible line 01 -> 24), drag-select + Ctrl+C
  reaches the clipboard (746 bytes of probe text), and dismisses when
  the pointer leaves or on click-away; re-shows after dismissal
- File menu popup renders with its full item list (OCR)
- #2983's X11 frame resynchronization still works: after normal and
  maximized states on all three monitors, the File menu popup opens
  aligned with the menu (popup x == client x, popup y == client y + 24)
  and remains open for at least 2.2 s; repeated maximize/restore cycles
  pass. `FrameResynchronizerTest` covers the geometry logic.

### Runtime verification — Windows 11 + JetBrains Runtime 21.0.11

The PR build was also verified on Windows 11 in QEMU (Chinese locale,
FreeRDP session) with the staged `flatlaf-3.7.2.jar` verified by
SHA-256 (`917aff3963c88d797d0fd9b9ccbd70f7681c101df9d11c59e2bc7a3a6c0fabf4`)
and no 3.6 jar present:

- Toolbar tooltips (the original reproducer): 120 cycles -> **65
  tooltips, 0 background-only/empty**; FlatDarkLaf, 40 cycles -> **26
  tooltips, 0 empty**
- Node tooltip deep check (render + wheel scroll + drag-select/Ctrl+C to
  clipboard + dismissal): passed in light theme (395x493, ink 0.062) and
  dark theme (391x497, ink 0.085)
- File menu popup: 260x551, ink 0.089

This complements the earlier 3.7.2 swap-in run recorded in #2983:
https://github.com/freeplane/freeplane/pull/2983#issuecomment-5619707522

### Risk

Low: a single dependency bump, no source changes required, all FlatLaf
APIs used by Freeplane remain available. Observed behavior change: on
Windows with 3.7.2 the simple tooltips were lightweight instead of
heavyweight in the swapped-jar configuration; no visual or interaction
regression was found in either configuration. macOS was not
runtime-tested in this round (no macOS host), though 3.7.2 contains the
macOS popup fixes.
